### PR TITLE
Map options

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <title>Planetary Response Network: event maps</title>
 <style>
   #map {
-    height: 100vh;
+    height: 95vh;
     width: 100vw;
     background: #ccc;
   }

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,17 @@
+const MAP_CONTAINER = document.getElementById('map');
 const MAP_THRESHOLD = document.getElementById('map-threshold');
 const MAP_SELECT = document.getElementById('map-select');
+const MAP_OPTIONS = {
+  zoom: 10,
+  mapTypeControl: true,
+  mapTypeControlOptions: {
+    style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
+    mapTypeIds: ['hybrid', 'satellite', 'roadmap', 'terrain']
+  },
+  mapTypeId: 'hybrid',
+  scaleControl: true,
+  streetViewControl: false
+}
 const HEATMAPS = {};
 
 function queryParams() {
@@ -33,11 +45,7 @@ API.events()
 .then(renderMapAndFit);
 
 const center = new google.maps.LatLng(15.231458142,-61.2507115);
-const map = new google.maps.Map(document.getElementById('map'), {
-  center,
-  zoom: 10,
-  mapTypeId: 'satellite'
-});
+const map = new google.maps.Map(MAP_CONTAINER, Object.assign(MAP_OPTIONS, { center }));
 
 const heatmap = new google.maps.visualization.HeatmapLayer({
   map,


### PR DESCRIPTION
Set some custom options for map appearance and controls.
 Hide streetview.
Add a scale control. 
Show map types as a dropdown menu.
Set the map height to 95% viewport height.