### PR TITLE
[WIP] add custom tile map for our event imagery

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,9 @@ const MAP_OPTIONS = {
   streetViewControl: false
 }
 const HEATMAPS = {};
+var TILE_URL = 'http://local.zooniverse.org:8080/data/palu_2018/{z}/{x}/{y}.png';
+
+const layerID = 'palu_2018_before';
 
 function queryParams() {
   const queryString = window.location.search.substring(1);
@@ -46,6 +49,25 @@ API.events()
 
 const center = new google.maps.LatLng(15.231458142,-61.2507115);
 const map = new google.maps.Map(MAP_CONTAINER, Object.assign(MAP_OPTIONS, { center }));
+
+// create the custom map tiles
+var customTileMap = new google.maps.ImageMapType({
+  name: layerID,
+  getTileUrl: function(coord, zoom) {
+    // console.log(coord);
+    var url = TILE_URL
+      .replace('{x}', coord.x)
+      .replace('{y}', coord.y)
+      .replace('{z}', zoom);
+    return url;
+  },
+  tileSize: new google.maps.Size(256, 256),
+  minZoom: 10,
+  maxZoom: 15
+});
+
+// add the tile map type as an overlay over the existing
+map.overlayMapTypes.insertAt(0, customTileMap);
 
 const heatmap = new google.maps.visualization.HeatmapLayer({
   map,
@@ -83,7 +105,7 @@ function parseMapData(results) {
 function cacheMapData(results, file) {
   const url = MAP_SELECT.value;
   HEATMAPS[url] = url ? results : undefined;
-  parseMapData(results); 
+  parseMapData(results);
 }
 
 function readMapFile(url) {


### PR DESCRIPTION
very much a work in progress PR as this is a very early implementation attempt. Add custom event source imagery tiles to the map via a maptile server. Relies on https://github.com/klokantech/tileserver-gl running on localhost

### Process to get the tile server working
1. create mbtiles data from source GeoTiff using https://www.maptiler.com/engine/
`docker run -ti --rm -v $(pwd):/data maptiler/engine maptiler -o palu_2018.mbtiles palu_2018_09_28_before_aoi_extract.tif`
0. From the directory containing the `palu_2018.mbtiles` file `docker run --rm -it -v $(pwd):/data -p 8080:80 klokantech/tileserver-gl`
    + check the tile server is running on http://localhost:8080

