### PR TITLE
Multiple heatmap layers

### DIFF
--- a/maps/index.html
+++ b/maps/index.html
@@ -1,33 +1,48 @@
 <!DOCTYPE html>
 <title>Planetary Response Network: event maps</title>
 <style>
+  body {
+    display: grid;
+    grid-template-columns: 1fr 4fr;
+    grid-gap: .5em;
+    font-family: sans-serif;
+    background: #fffefd;
+    color: #000102;
+    margin: .5em;
+    font-size: .9em;
+    line-height: 1.5;
+  }
+
+  #map-select label {
+    display: block;
+  }
   #map {
     height: 95vh;
-    width: 100vw;
+    width: 100%;
     background: #ccc;
   }
 </style>
-<label>
-  Select a heat map:
-  <select id="map-select">
-    <option value="0" checked>overlay_0.csv</option>
-    <option value="1" checked>overlay_1.csv</option>
-    <option value="2" checked>overlay_2.csv</option>
-    <option value="3" checked>overlay_3.csv</option>
-  </select>
-</label>
-<label>
-  Threshold:
-  1
-  <input
-    id="map-threshold"
-    type="range"
-    min="1"
-    max="5"
-    value="2"
-  >
-  5
-</label>
+<div>
+  <fieldset id="map-select">
+    <legend>Select a heat map:</legend>
+    <label><input type=checkbox value=0>overlay_0.csv</label>
+    <label><input type=checkbox value=1>overlay_1.csv</label>
+    <label><input type=checkbox value=2>overlay_2.csv</label>
+    <label><input type=checkbox value=3>overlay_3.csv</label>
+  </fieldset>
+  <label>
+    Threshold:
+    1
+    <input
+      id="map-threshold"
+      type="range"
+      min="1"
+      max="5"
+      value="2"
+    >
+    5
+  </label>
+</div>
 <div id="map">
   Loading…
 </div>
@@ -35,4 +50,4 @@
 <script src="/js/superagent.js"></script>
 <script src="/js/papaparse.min.js"></script>
 <script src="/js/api.js"></script>
-<script src="/js/app.js"></script>
+<script src="/js/maps.js"></script>


### PR DESCRIPTION
Update map page layout.
Replace layer select with checkboxes.
Rename app.js -> maps.js.
Allow for multiple heatmaps.
Cache heatmap layers and add/remove them when the correspondng checkbox toggles.

Closes #8.