### PR TITLE
Add Colours to Heatmap Layers

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -16,11 +16,8 @@ const HEATMAPS = {};
 const HEATMAP_DATA = {};
 const HEATMAP_COLOURS = [  // Pre-set colour gradients for each heatmap
   ['transparent', '#844', '#c44', '#f44', '#f00'],
-  ['transparent', '#844', '#c44', '#f44', '#f00'],
-  ['transparent', '#844', '#c44', '#f44', '#f00'],
-  ['transparent', '#844', '#c44', '#f44', '#f00'],
-  ['transparent', '#844', '#c44', '#f44', '#f00'],
-  ['transparent', '#844', '#c44', '#f44', '#f00'],
+  ['transparent', '#484', '#484', '#4f4', '#0f0'],
+  ['transparent', '#448', '#44c', '#44f', '#00f'],
 ];
 
 
@@ -89,10 +86,10 @@ function parseMapData(results, url) {
   // For each heatmap, assign a preset colour to it.
   const numberOfHeatmaps = Object.keys(HEATMAPS).length;
   const colourIndex = numberOfHeatmaps % HEATMAP_COLOURS.length;
-  const gradient = HEATMAP_COLOURS[colourIndex];
+  const heatmapColour = HEATMAP_COLOURS[colourIndex];
   
   const heatmap = new google.maps.visualization.HeatmapLayer({
-    gradient,
+    gradient: heatmapColour,
     maxIntensity: 30,
     opacity: .4
   });

--- a/js/maps.js
+++ b/js/maps.js
@@ -14,6 +14,15 @@ const MAP_OPTIONS = {
 }
 const HEATMAPS = {};
 const HEATMAP_DATA = {};
+const HEATMAP_COLOURS = [  // Pre-set colour gradients for each heatmap
+  ['transparent', '#844', '#c44', '#f44', '#f00'],
+  ['transparent', '#844', '#c44', '#f44', '#f00'],
+  ['transparent', '#844', '#c44', '#f44', '#f00'],
+  ['transparent', '#844', '#c44', '#f44', '#f00'],
+  ['transparent', '#844', '#c44', '#f44', '#f00'],
+  ['transparent', '#844', '#c44', '#f44', '#f00'],
+];
+
 
 function queryParams() {
   const queryString = window.location.search.substring(1);
@@ -77,7 +86,13 @@ function filteredMapData(results) {
 }
 
 function parseMapData(results, url) {
+  // For each heatmap, assign a preset colour to it.
+  const numberOfHeatmaps = Object.keys(HEATMAPS).length;
+  const colourIndex = numberOfHeatmaps % HEATMAP_COLOURS.length;
+  const gradient = HEATMAP_COLOURS[colourIndex];
+  
   const heatmap = new google.maps.visualization.HeatmapLayer({
+    gradient,
     maxIntensity: 30,
     opacity: .4
   });

--- a/js/maps.js
+++ b/js/maps.js
@@ -14,11 +14,20 @@ const MAP_OPTIONS = {
 }
 const HEATMAPS = {};
 const HEATMAP_DATA = {};
-const HEATMAP_COLOURS = [  // Pre-set colour gradients for each heatmap
-  ['transparent', '#844', '#c44', '#f44', '#f00'],
-  ['transparent', '#484', '#484', '#4f4', '#0f0'],
-  ['transparent', '#448', '#44c', '#44f', '#00f'],
+
+let HEATMAP_COLOURS = [  // Pre-set colour gradients for each heatmap
+  ['rgba(204, 068, 068, 0.0)', 'rgba(204, 068, 068, 0.6)', 'rgba(255, 136, 136, 0.6)'],  // Red
+  ['rgba(204, 204, 068, 0.0)', 'rgba(204, 204, 068, 0.6)', 'rgba(255, 255, 136, 0.6)'],  // Yellow
+  ['rgba(068, 204, 204, 0.0)', 'rgba(068, 204, 204, 0.6)', 'rgba(136, 255, 255, 0.6)'],  // Cyan
+  ['rgba(068, 204, 068, 0.0)', 'rgba(068, 204, 068, 0.6)', 'rgba(136, 255, 136, 0.6)'],  // Green
+  ['rgba(204, 068, 204, 0.0)', 'rgba(204, 068, 204, 0.6)', 'rgba(255, 136, 255, 0.6)'],  // Magenta
+  ['rgba(068, 068, 204, 0.0)', 'rgba(068, 068, 204, 0.6)', 'rgba(136, 136, 255, 0.6)'],  // Blue
 ];
+// Pad the colour gradient to favour the high-intensity colours.
+// We need at least 8 steps in the gradient - the first being transparent - for this to look good.
+HEATMAP_COLOURS = HEATMAP_COLOURS.map(function spreadColours(arr) {
+  return [arr[0], arr[1], arr[1], arr[1], arr[2], arr[2], arr[2], arr[2]];
+});
 
 
 function queryParams() {
@@ -91,7 +100,7 @@ function parseMapData(results, url) {
   const heatmap = new google.maps.visualization.HeatmapLayer({
     gradient: heatmapColour,
     maxIntensity: 30,
-    opacity: .4
+    opacity: 1
   });
   bounds  = new google.maps.LatLngBounds();
   const heatmapData = filteredMapData(results);


### PR DESCRIPTION
## PR Overview
This PR adds individual colours to each layer of the heatmap, to make each layer distinct. Closes #12 

Goals of this PR:
- [x] for each unique layer of the heatmap, generate a unique identifying colour
- [ ] the colours must be identifiable at whichever zoom level. _(Shaun's note: early tests indicate that simple gradients can uselessly faint at high zoom levels, making the heatmap with custom gradients only visible at far-out zooms.)_

Extended/Optional Goals:
- [ ] keep assignment of colours consistent (e.g. vegetation layer should always use the green gradient, water layer should always use the blue gradient, etc)
- [ ] allow users to switch colours.

### Status
WIP