### PR TITLE
Add basic "Upload File" page

### DIFF
--- a/css/upload.css
+++ b/css/upload.css
@@ -21,3 +21,10 @@
   display: block;
   color: #888;
 }
+
+#upload-page form #submit-button {
+  display: inline-block;
+  background: #4c8;
+  color: #fff;
+  padding: 0.5em 1em;
+}

--- a/css/upload.css
+++ b/css/upload.css
@@ -3,26 +3,26 @@
   padding: 0.5em;
 }
 
-#upload-page form .row {
+#upload-page .row {
   padding: 0.5em
 }
 
-#upload-page form .row label {
+#upload-page .row label {
   display: block;
   font-weight: bold;
 }
 
-#upload-page form #metadata {
+#upload-page #metadata {
   width: 24em;
   height: 16em;
 }
 
-#upload-page form #metadata-status {
+#upload-page #metadata-status {
   display: block;
   color: #888;
 }
 
-#upload-page form #submit-button {
+#upload-page #submit-button {
   display: inline-block;
   background: #4c8;
   color: #fff;

--- a/css/upload.css
+++ b/css/upload.css
@@ -12,13 +12,7 @@
   font-weight: bold;
 }
 
-#upload-page #metadata {
-  width: 24em;
-  height: 16em;
-}
-
-#upload-page #metadata-status {
-  display: block;
+#upload-page #status-text {
   color: #888;
 }
 

--- a/css/upload.css
+++ b/css/upload.css
@@ -1,0 +1,23 @@
+#upload-page form {
+  border: 1px solid #ccc;
+  padding: 0.5em;
+}
+
+#upload-page form .row {
+  padding: 0.5em
+}
+
+#upload-page form .row label {
+  display: block;
+  font-weight: bold;
+}
+
+#upload-page form #metadata {
+  width: 24em;
+  height: 16em;
+}
+
+#upload-page form #metadata-status {
+  display: block;
+  color: #888;
+}

--- a/js/api.js
+++ b/js/api.js
@@ -20,7 +20,7 @@ const API = {
     })
     .catch(function (error) {
       console.error(error);
-      return defaultValue;
+      return error;
     });
   },
   approve: function (eventName) {

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,5 +1,8 @@
 const htmlUploadForm = document.getElementById('upload-form');
-const htmlEvent = document.getElementById('event');
+const htmlEventList = document.getElementById('event-list');
+const htmlStatusText = document.getElementById('status-text');
+const htmlMetadataFile = document.getElementById('metadata-file');
+const htmlLayersFiles = document.getElementById('layers-files');
 //const htmlMetadata = document.getElementById('metadata');
 //const htmlMetadataStatus = document.getElementById('metadata-status');
 const htmlSubmitButton = document.getElementById('submit-button');
@@ -16,27 +19,51 @@ const htmlSubmitButton = document.getElementById('submit-button');
 }*/
 
 function updateFormAction() {
-  const eventName = htmlEvent.value;
+  const eventName = htmlEventList.value;
   const url = API.host + '/upload/layers/' + eventName;
   htmlUploadForm.action = url;
+  
+  htmlStatusText.textContent = 'Files will be uploaded to ' + eventName;
 }
 
 function updateEventsList(events) {
   events.forEach(function (event, index) {
-    const newOption = document.createElement("option");
+    const newOption = document.createElement('option');
     newOption.value = event.name;
     newOption.textContent = event.name;
     
-    htmlEvent.appendChild(newOption);
+    htmlEventList.appendChild(newOption);
   });
   
-  htmlEvent.selectedIndex = 0;
+  htmlEventList.selectedIndex = 0;
   updateFormAction();
 }
 
 function submit() {
-  console.log('PLACEHOLDER: DATA SUBMISSION');
-  console.log('Either replace this button with a button.type=submit or hook up submit() to the API.')
+  htmlStatusText.textContent = 'Uploading...';
+  
+  const request = superagent
+    .post(htmlUploadForm.action)
+    .withCredentials();
+  
+  // Attach the metadata file
+  if (htmlMetadataFile.files.length > 0) {                                    
+    request.attach(htmlMetadataFile.name, htmlMetadataFile.files[0]);
+  }
+  
+  // Attach each Layer file
+  Array.from(htmlLayersFiles.files).forEach(function (file) {
+    request.attach(htmlLayersFiles.name, file);
+  });
+  
+  // Send!
+  request.then(function onUploadComplete(res) {
+    htmlStatusText.textContent = '[Upload Complete] ' + res;
+  })
+  .catch(function onUploadError(err) {
+    console.log('+++ ERR: ', err);
+    htmlStatusText.textContent = '[Upload Error] ' + err;
+  });
 }
 
 /*htmlMetadata.onkeyup = checkMetadata;
@@ -45,6 +72,6 @@ htmlMetadata.onpaste = checkMetadata;
 checkMetadata();*/
 
 API.events().then(updateEventsList)
-htmlEvent.onchange = updateFormAction;
+htmlEventList.onchange = updateFormAction;
 
-//htmlSubmitButton.onclick = submit;
+htmlSubmitButton.onclick = submit;

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,0 +1,25 @@
+const htmlMetadata = document.getElementById('metadata');
+const htmlMetadataStatus = document.getElementById('metadata-status');
+const htmlSubmitButton = document.getElementById('submit-button');
+
+function checkMetadata() {
+  const metadata = htmlMetadata.value;
+
+  try {
+    const json = JSON.parse(metadata);
+    htmlMetadataStatus.textContent = 'JSON OK';
+  } catch (err) {
+    htmlMetadataStatus.textContent = 'Invalid JSON: ' + err;
+  }
+}
+
+function submit() {
+  console.log('PLACEHOLDER: DATA SUBMISSION');
+}
+
+htmlMetadata.onkeyup = checkMetadata;
+htmlMetadata.onblur = checkMetadata;
+htmlMetadata.onpaste = checkMetadata;
+checkMetadata();
+
+htmlSubmitButton.onclick = submit;

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,3 +1,4 @@
+const htmlEvent = document.getElementById('event');
 const htmlMetadata = document.getElementById('metadata');
 const htmlMetadataStatus = document.getElementById('metadata-status');
 const htmlSubmitButton = document.getElementById('submit-button');
@@ -13,6 +14,18 @@ function checkMetadata() {
   }
 }
 
+function updateEventsList(events) {
+  console.log(events);
+  
+  events.forEach(function (event) {
+    const newOption = document.createElement("option");
+    newOption.value = event.name;
+    newOption.textContent = event.name;
+    
+    htmlEvent.appendChild(newOption);
+  })
+}
+
 function submit() {
   console.log('PLACEHOLDER: DATA SUBMISSION');
   console.log('Either replace this button with a button.type=submit or hook up submit() to the API.')
@@ -22,5 +35,7 @@ htmlMetadata.onkeyup = checkMetadata;
 htmlMetadata.onblur = checkMetadata;
 htmlMetadata.onpaste = checkMetadata;
 checkMetadata();
+
+API.events().then(updateEventsList)
 
 htmlSubmitButton.onclick = submit;

--- a/js/upload.js
+++ b/js/upload.js
@@ -58,11 +58,23 @@ function submit() {
   
   // Send!
   request.then(function onUploadComplete(res) {
-    htmlStatusText.textContent = '[Upload Complete] ' + res;
+    console.log('onUploadComplete', res);
+    
+    if (!res.ok) {
+      throw 'General Error - server returned ' + res.status;
+    }
+    
+    htmlStatusText.textContent = '[Upload Complete] All OK!';
   })
   .catch(function onUploadError(err) {
-    console.log('+++ ERR: ', err);
-    htmlStatusText.textContent = '[Upload Error] ' + err;
+    let errorMessage = err;
+    
+    if (err.response && err.response.body && err.response.body.errors) {
+      errorMessage = err.response.body.errors.join(' ; ');
+    }
+    
+    console.error('onUploadError: ', err);
+    htmlStatusText.textContent = '[Upload Error] ' + errorMessage;
   });
 }
 

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,10 +1,10 @@
 const htmlUploadForm = document.getElementById('upload-form');
 const htmlEvent = document.getElementById('event');
-const htmlMetadata = document.getElementById('metadata');
-const htmlMetadataStatus = document.getElementById('metadata-status');
+//const htmlMetadata = document.getElementById('metadata');
+//const htmlMetadataStatus = document.getElementById('metadata-status');
 const htmlSubmitButton = document.getElementById('submit-button');
 
-function checkMetadata() {
+/*function checkMetadata() {
   const metadata = htmlMetadata.value;
 
   try {
@@ -13,7 +13,7 @@ function checkMetadata() {
   } catch (err) {
     htmlMetadataStatus.textContent = 'Invalid JSON: ' + err;
   }
-}
+}*/
 
 function updateFormAction() {
   const eventName = htmlEvent.value;
@@ -39,12 +39,12 @@ function submit() {
   console.log('Either replace this button with a button.type=submit or hook up submit() to the API.')
 }
 
-htmlMetadata.onkeyup = checkMetadata;
+/*htmlMetadata.onkeyup = checkMetadata;
 htmlMetadata.onblur = checkMetadata;
 htmlMetadata.onpaste = checkMetadata;
-checkMetadata();
+checkMetadata();*/
 
 API.events().then(updateEventsList)
 htmlEvent.onchange = updateFormAction;
 
-htmlSubmitButton.onclick = submit;
+//htmlSubmitButton.onclick = submit;

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,3 +1,4 @@
+const htmlUploadForm = document.getElementById('upload-form');
 const htmlEvent = document.getElementById('event');
 const htmlMetadata = document.getElementById('metadata');
 const htmlMetadataStatus = document.getElementById('metadata-status');
@@ -14,16 +15,23 @@ function checkMetadata() {
   }
 }
 
+function updateFormAction() {
+  const eventName = htmlEvent.value;
+  const url = API.host + '/upload/layers/' + eventName;
+  htmlUploadForm.action = url;
+}
+
 function updateEventsList(events) {
-  console.log(events);
-  
-  events.forEach(function (event) {
+  events.forEach(function (event, index) {
     const newOption = document.createElement("option");
     newOption.value = event.name;
     newOption.textContent = event.name;
     
     htmlEvent.appendChild(newOption);
-  })
+  });
+  
+  htmlEvent.selectedIndex = 0;
+  updateFormAction();
 }
 
 function submit() {
@@ -37,5 +45,6 @@ htmlMetadata.onpaste = checkMetadata;
 checkMetadata();
 
 API.events().then(updateEventsList)
+htmlEvent.onchange = updateFormAction;
 
 htmlSubmitButton.onclick = submit;

--- a/js/upload.js
+++ b/js/upload.js
@@ -15,6 +15,7 @@ function checkMetadata() {
 
 function submit() {
   console.log('PLACEHOLDER: DATA SUBMISSION');
+  console.log('Either replace this button with a button.type=submit or hook up submit() to the API.')
 }
 
 htmlMetadata.onkeyup = checkMetadata;

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -12,18 +12,6 @@
   </section>
   
   <form id="upload-form" method="post" action="#" enctype="multipart/form-data">
-    <!--
-    <div class="row">
-      <label for="metadata">Metadata</label>
-<textarea id="metadata" name="metadata">
-{
-  "key1": "value1",
-  "key2": "value2"
-}
-</textarea>
-      <span id="metadata-status"></span>
-    </div>
-    -->
     <div class="row">
       <label for="metadata-file">Metadata File (JSON)</label>
       <input id="metadata-file" name="metadata" type="file" accept=".json">

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -25,8 +25,12 @@
     </div>
     -->
     <div class="row">
-      <label for="data">Files</label>
-      <input id="data" name="data" type="file" accept=".csv, .json" multiple>
+      <label for="metadata">Metadata File (JSON)</label>
+      <input id="metadata-file" name="metadata" type="file" accept=".json">
+    </div>
+    <div class="row">
+      <label for="layers[]">Layers Files (CSVs)</label>
+      <input id="layers-files" name="layers[]" type="file" accept=".csv" multiple>
     </div>
     <div class="row">
       <input id="submit-button" type="submit" value="Upload">

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -6,6 +6,11 @@
 <main id="upload-page">
   <form method="post" action="https://maps-api.planetaryresponsenetwork.org/uploads">
     <div class="row">
+      <label for="metadata" for="event">Event Name</label>
+      <select id="event" name="event"></select>
+    </div>
+    
+    <div class="row">
       <label for="metadata">Metadata</label>
 <textarea id="metadata" name="metadata">
 {

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -12,6 +12,7 @@
   </section>
   
   <form id="upload-form" method="post" action="#" enctype="multipart/form-data">
+    <!--
     <div class="row">
       <label for="metadata">Metadata</label>
 <textarea id="metadata" name="metadata">
@@ -22,12 +23,13 @@
 </textarea>
       <span id="metadata-status"></span>
     </div>
+    -->
     <div class="row">
       <label for="data">Files</label>
       <input id="data" name="data" type="file" accept=".csv, .json" multiple>
     </div>
     <div class="row">
-      <input id="submit-button" type="button" value="Upload">
+      <input id="submit-button" type="submit" value="Upload">
     </div>
   </form>
 </main>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -4,12 +4,14 @@
 <link rel="stylesheet" type="text/css" href="/css/upload.css">
 
 <main id="upload-page">
-  <form id="upload-form" method="post" action="#" enctype="multipart/form-data">
+  <section>
     <div class="row">
       <label for="metadata" for="event">Event Name</label>
       <select id="event" name="event"></select>
     </div>
-    
+  </section>
+  
+  <form id="upload-form" method="post" action="#" enctype="multipart/form-data">
     <div class="row">
       <label for="metadata">Metadata</label>
 <textarea id="metadata" name="metadata">

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -4,9 +4,9 @@
 <link rel="stylesheet" type="text/css" href="/css/upload.css">
 
 <main id="upload-page">
-  <form>
+  <form method="post" action="https://maps-api.planetaryresponsenetwork.org/uploads">
     <div class="row">
-      <label>Metadata</label>
+      <label for="metadata">Metadata</label>
 <textarea id="metadata" name="metadata">
 {
   "key1": "value1",
@@ -16,8 +16,8 @@
       <span id="metadata-status"></span>
     </div>
     <div class="row">
-      <label>Files</label>
-      <input name="data" type="file" accept=".csv, .json" multiple>
+      <label for="data">Files</label>
+      <input id="data" name="data" type="file" accept=".csv, .json" multiple>
     </div>
     <div class="row">
       <input id="submit-button" type="button" value="Upload">

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -4,7 +4,7 @@
 <link rel="stylesheet" type="text/css" href="/css/upload.css">
 
 <main id="upload-page">
-  <form method="post" action="https://maps-api.planetaryresponsenetwork.org/uploads">
+  <form id="upload-form" method="post" action="#" enctype="multipart/form-data">
     <div class="row">
       <label for="metadata" for="event">Event Name</label>
       <select id="event" name="event"></select>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -6,8 +6,8 @@
 <main id="upload-page">
   <section>
     <div class="row">
-      <label for="metadata" for="event">Event Name</label>
-      <select id="event" name="event"></select>
+      <label for="metadata" for="event-list">Event Name</label>
+      <select id="event-list" name="event-list"></select>
     </div>
   </section>
   
@@ -33,7 +33,10 @@
       <input id="layers-files" name="layers[]" type="file" accept=".csv" multiple>
     </div>
     <div class="row">
-      <input id="submit-button" type="submit" value="Upload">
+      <input id="submit-button" type="button" value="Upload">
+    </div>
+    <div class="row">
+      <span id="status-text"></span>
     </div>
   </form>
 </main>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Planetary Response Network: file uploader</title>
+<link rel="stylesheet" type="text/css" href="/css/main.css">
+<main id="upload-page">
+  <form>
+    <div class="row">
+      <label>Files</label>
+      <input type="file" accept=".csv, .json" multiple>
+    </div>
+    <div class="row">
+      <input type="submit" value="Upload">
+    </div>
+  </form>
+</main>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -4,11 +4,62 @@
 <main id="upload-page">
   <form>
     <div class="row">
+      <label>Metadata</label>
+<textarea id="metadata" name="metadata">
+{
+  "key1": "value1",
+  "key2": "value2"
+}
+</textarea>
+      <span id="metadata-status"></span>
+    </div>
+    <div class="row">
       <label>Files</label>
-      <input type="file" accept=".csv, .json" multiple>
+      <input name="data" type="file" accept=".csv, .json" multiple>
     </div>
     <div class="row">
       <input type="submit" value="Upload">
     </div>
   </form>
 </main>
+
+<style>
+  #upload-page form {
+    
+  }
+  
+  #upload-page form .row {
+    padding: 1em
+  }
+  
+  #upload-page form .row label {
+    display: block;
+    font-weight: bold;
+  }
+  
+  #upload-page form #metadata {
+    width: 24em;
+    height: 16em;
+  }
+</style>
+  
+<script>
+  const htmlMetadata = document.getElementById('metadata');
+  const htmlMetadataStatus = document.getElementById('metadata-status');
+  
+  function checkMetadata() {
+    const metadata = htmlMetadata.value;
+    
+    try {
+      const json = JSON.parse(metadata);
+      htmlMetadataStatus.textContent = 'JSON OK';
+    } catch (err) {
+      htmlMetadataStatus.textContent = 'Invalid JSON: ' + err;
+    }
+  }
+  
+  htmlMetadata.onkeyup = checkMetadata;
+  htmlMetadata.onblur = checkMetadata;
+  htmlMetadata.onpaste = checkMetadata;
+  checkMetadata();
+</script>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <title>Planetary Response Network: file uploader</title>
 <link rel="stylesheet" type="text/css" href="/css/main.css">
+<link rel="stylesheet" type="text/css" href="/css/upload.css">
+
 <main id="upload-page">
   <form>
     <div class="row">
@@ -18,48 +20,11 @@
       <input name="data" type="file" accept=".csv, .json" multiple>
     </div>
     <div class="row">
-      <input type="submit" value="Upload">
+      <input id="submit-button" type="button" value="Upload">
     </div>
   </form>
 </main>
 
-<style>
-  #upload-page form {
-    
-  }
-  
-  #upload-page form .row {
-    padding: 1em
-  }
-  
-  #upload-page form .row label {
-    display: block;
-    font-weight: bold;
-  }
-  
-  #upload-page form #metadata {
-    width: 24em;
-    height: 16em;
-  }
-</style>
-  
-<script>
-  const htmlMetadata = document.getElementById('metadata');
-  const htmlMetadataStatus = document.getElementById('metadata-status');
-  
-  function checkMetadata() {
-    const metadata = htmlMetadata.value;
-    
-    try {
-      const json = JSON.parse(metadata);
-      htmlMetadataStatus.textContent = 'JSON OK';
-    } catch (err) {
-      htmlMetadataStatus.textContent = 'Invalid JSON: ' + err;
-    }
-  }
-  
-  htmlMetadata.onkeyup = checkMetadata;
-  htmlMetadata.onblur = checkMetadata;
-  htmlMetadata.onpaste = checkMetadata;
-  checkMetadata();
-</script>
+<script src="/js/superagent.js"></script>
+<script src="/js/api.js"></script>
+<script src="/js/upload.js"></script>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -25,11 +25,11 @@
     </div>
     -->
     <div class="row">
-      <label for="metadata">Metadata File (JSON)</label>
+      <label for="metadata-file">Metadata File (JSON)</label>
       <input id="metadata-file" name="metadata" type="file" accept=".json">
     </div>
     <div class="row">
-      <label for="layers[]">Layers Files (CSVs)</label>
+      <label for="layers-files">Layers Files (CSVs)</label>
       <input id="layers-files" name="layers[]" type="file" accept=".csv" multiple>
     </div>
     <div class="row">


### PR DESCRIPTION
## PR Overview

This PR adds a form for _(theoretically authenticated)_ to upload data files _(heatmap layers)_ to an endpoint. Closes #7 ; check that issue for full requirement details/discussion.

Goals:
- [ ] user must be able to submit their files (CSV? JSON?) to an API endpoint.
- [ ] in the submission process, user must also be able to add the layer's _metadata_ via a JSON text string. 
  - _12 Mar update: we are now considering allowing users to upload JSON files instead of letting them edit a JSON string._

Extended Goals:
- [x] ~~said user must be authenticated.~~ (⚠️ if not tackled in this PR, then definitely in a later authentication PR)
  - _12 Mar update: [Jim pointed out that this may not be a worry.](https://github.com/zooniverse/PRN-maps/pull/16#issuecomment-471463717)_

### Status

WIP

At the moment (Fri 8 Mar), there is _no endpoint_ to submit the files to. Details for this will be discussed with @camallen 