### PR TITLE
Group Layers by Versions

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -13,9 +13,21 @@ body {
   grid-gap: .5em;
 }
 
+
+#map-select .group {
+  border: 1px solid #ccc;
+  padding: 0.5em;
+  margin-bottom: 0.5em
+}
+#map-select h6 {
+  padding: 0;
+  margin: 0.5em 0;
+}
 #map-select label {
   display: block;
 }
+
+
 #map {
   height: 95vh;
   width: 100%;

--- a/css/main.css
+++ b/css/main.css
@@ -26,6 +26,16 @@ body {
 #map-select label {
   display: block;
 }
+#map-select .submenu {
+  background: #ccc;
+  padding: 0.25em;
+  display: flex;
+}
+#map-select .submenu * {
+  flex: 1 1 auto;
+}
+#map-select .submenu .metadata-link {}
+#map-select .submenu .approve-button {}
 
 
 #map {

--- a/js/api.js
+++ b/js/api.js
@@ -23,8 +23,8 @@ const API = {
       return error;
     });
   },
-  approve: function (eventName) {
-    return API.post(`/pending/layers/${eventName}/approve`);
+  approve: function (eventName, versionGroup) {
+    return API.post(`/pending/layers/${eventName}/approve/${versionGroup}`);
   },
   events: function () {
     return API.get('/events', []);

--- a/js/maps.js
+++ b/js/maps.js
@@ -74,9 +74,20 @@ function buildLayerGroup(versionGroup) {
     htmlSubmenu.appendChild(htmlApproveButton);
     
     htmlApproveButton.onclick = function() {
-      console.log('!!');
       htmlApproveButton.textContent = 'Approving...';
       htmlApproveButton.onclick = undefined;
+      
+      API.approve(eventName, versionGroup.version)
+        .then(function (res) {
+          if (!res.ok) {
+            throw 'General Error - server returned ' + res.status;
+          }
+          htmlApproveButton.textContent = 'DONE!';
+        })
+        .catch(function (err) {
+          console.error(err);
+          htmlApproveButton.textContent = 'ERROR';
+        });
     };
   }
   

--- a/js/maps.js
+++ b/js/maps.js
@@ -41,7 +41,7 @@ function queryParams() {
 }
 
 function buildLayersMenu(layers) {
-  document.querySelectorAll('#map-select label').forEach(function (node) {
+  document.querySelectorAll('#map-select .group').forEach(function (node) {
     MAP_SELECT.removeChild(node);
   });
   layers
@@ -50,6 +50,7 @@ function buildLayersMenu(layers) {
 }
 function buildLayerGroup(versionGroup) {
   const htmlGroup = document.createElement('div');
+  htmlGroup.className = 'group';
   
   const htmlHeader = document.createElement('h6');
   htmlHeader.textContent = versionGroup.version;

--- a/js/maps.js
+++ b/js/maps.js
@@ -40,6 +40,29 @@ function queryParams() {
   }, {});
 }
 
+function buildLayersMenu(layers) {
+  document.querySelectorAll('#map-select label').forEach(function (node) {
+    MAP_SELECT.removeChild(node);
+  });
+  layers
+    .map(buildLayerGroup)
+    .forEach(function (htmlGroup) { MAP_SELECT.appendChild(htmlGroup) });
+}
+function buildLayerGroup(versionGroup) {
+  const htmlGroup = document.createElement('div');
+  
+  const htmlHeader = document.createElement('h6');
+  htmlHeader.textContent = versionGroup.version;
+  htmlGroup.append(htmlHeader);
+  
+  //const htmlApproveButton = document.createElement('button');
+  
+  versionGroup.layers
+    .map(buildLayerInput)
+    .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
+  
+  return htmlGroup;
+}
 function buildLayerInput(layer) {
   const option = document.createElement('label');
   const checkbox = document.createElement('input');
@@ -50,16 +73,6 @@ function buildLayerInput(layer) {
   option.appendChild(checkbox)
   option.appendChild(text);
   return option;
-}
-function buildLayersMenu(layers) {
-  document.querySelectorAll('#map-select label').forEach(function (node) {
-    MAP_SELECT.removeChild(node);
-  });
-  layers
-    .map(buildLayerInput)
-    .forEach(function (input) {
-      MAP_SELECT.appendChild(input);
-    });
 }
 
 const eventName = queryParams().event

--- a/js/maps.js
+++ b/js/maps.js
@@ -54,9 +54,31 @@ function buildLayerGroup(versionGroup) {
   
   const htmlHeader = document.createElement('h6');
   htmlHeader.textContent = versionGroup.version;
-  htmlGroup.append(htmlHeader);
+  htmlGroup.appendChild(htmlHeader);
   
-  //const htmlApproveButton = document.createElement('button');
+  const htmlSubmenu = document.createElement('div');
+  htmlSubmenu.className = 'submenu';
+  htmlGroup.appendChild(htmlSubmenu);
+  
+  const htmlMetadataLink = document.createElement('a');
+  htmlMetadataLink.className = 'metadata-link';
+  htmlMetadataLink.href = versionGroup.metadata_url;
+  htmlMetadataLink.target = '_blank';
+  htmlMetadataLink.textContent = 'Metadata';
+  htmlSubmenu.appendChild(htmlMetadataLink);
+
+  if (queryParams().pending) {
+    const htmlApproveButton = document.createElement('button');
+    htmlApproveButton.className = 'approve-button';
+    htmlApproveButton.textContent = 'Approve';
+    htmlSubmenu.appendChild(htmlApproveButton);
+    
+    htmlApproveButton.onclick = function() {
+      console.log('!!');
+      htmlApproveButton.textContent = 'Approving...';
+      htmlApproveButton.onclick = undefined;
+    };
+  }
   
   versionGroup.layers
     .map(buildLayerInput)
@@ -130,7 +152,6 @@ function parseMapData(results, url) {
 
 function cacheMapData(results, file) {
   const url = file.streamer._input;
-  console.log(url)
   HEATMAP_DATA[url] = url ? results : undefined;
   parseMapData(results, url); 
 }
@@ -142,7 +163,6 @@ function readMapFile(url) {
     skipEmptyLines: true,
     chunk: cacheMapData
   }
-  console.log(url)
   Papa.parse(url, config);
 }
 

--- a/maps/index.html
+++ b/maps/index.html
@@ -5,10 +5,13 @@
   <div>
     <fieldset id="map-select">
       <legend>Select a heat map:</legend>
-      <label><input type=checkbox value=0>overlay_0.csv</label>
-      <label><input type=checkbox value=1>overlay_1.csv</label>
-      <label><input type=checkbox value=2>overlay_2.csv</label>
-      <label><input type=checkbox value=3>overlay_3.csv</label>
+      <div class="group">
+        <h6>v0</h6>
+        <label><input type=checkbox value=0>overlay_0.csv</label>
+        <label><input type=checkbox value=1>overlay_1.csv</label>
+        <label><input type=checkbox value=2>overlay_2.csv</label>
+        <label><input type=checkbox value=3>overlay_3.csv</label>
+      </div>
     </fieldset>
     <label>
       Threshold:


### PR DESCRIPTION
## PR Overview

This PR updates the map to reflect the new changes to the PRN API. The API now returns layers _grouped by "versions",_ with each "version" representing a batch of layers that were uploaded by an admin at one time.

(e.g. when Jim submits a batch of files, via the Upload form, with 1 metadata JSON and 4 layer/heatmap CSV files, those 4 layers will be grouped under "version v1". If he then uploads 1 JSON + 7 CSV files, those 7 layers will be grouped under "version v2". Etc etc)

Previous API response:
```
[
  {
    "name": "overlay_0",
    "url":"https://planetary-response-network.s3.amazonaws.com/events/dominica_2018_demo/layers/pending/v2/overlay_0.csv"
  }
]
```

New (current) API response:
```
[
  {
    "version": "v2",
    "metadata_url": "https://planetary-response-network.s3.amazonaws.com/events/dominica_2018_demo/layers/pending/v2/metadata.json",
    "layers": [
      {
        "name": "overlay_0",
        "url":"https://planetary-response-network.s3.amazonaws.com/events/dominica_2018_demo/layers/pending/v2/overlay_0.csv"
      }
    ]
  }
]
```


### Notes for Testing

To view the map with pending layers: `http://local.zooniverse.org:3735/maps/?event=dominica_2018_demo&pending=1`

To view the map with approved layers: `http://local.zooniverse.org:3735/maps/?event=dominica_2018_demo`

### Status
WIP

Goals:
- [x] Map should now display data from the updated API
- [x] Map should group layers by their version group
- [x] Each Version Group in PENDING MODE should have an "Approve" button

Current Screenshot:
![Screen Shot 2019-03-18 at 16 33 33](https://user-images.githubusercontent.com/13952701/54546500-b8c22300-499b-11e9-96b6-e02eb176a1a0.png)
