### PR TITLE
Set map bounds from event metadata

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -111,9 +111,6 @@ function buildLayerInput(layer) {
 
 const eventName = queryParams().event
 const getLayers = queryParams().pending ? 'pendingLayers' : 'layers';
-API[getLayers](eventName)
-  .then(buildLayersMenu)
-  .then(renderMapAndFit);
 
 const center = new google.maps.LatLng(15.231458142,-61.2507115);
 const map = new google.maps.Map(MAP_CONTAINER, Object.assign(MAP_OPTIONS, { center }));
@@ -197,5 +194,9 @@ function renderMapAndFit() {
   })
 }
 
-MAP_SELECT.addEventListener('change', renderMapAndFit);
+MAP_SELECT.addEventListener('change', renderMap);
 MAP_THRESHOLD.addEventListener('change', renderMap);
+
+API[getLayers](eventName)
+  .then(buildLayersMenu)
+  .then(renderMapAndFit);

--- a/js/maps.js
+++ b/js/maps.js
@@ -118,9 +118,6 @@ API[getLayers](eventName)
 const center = new google.maps.LatLng(15.231458142,-61.2507115);
 const map = new google.maps.Map(MAP_CONTAINER, Object.assign(MAP_OPTIONS, { center }));
 
-let bounds;
-let fitToBounds = false;
-
 function minimumWeight([lat, lng, weight]) {
   const threshold = parseInt(MAP_THRESHOLD.value);
   return weight > threshold;
@@ -128,7 +125,6 @@ function minimumWeight([lat, lng, weight]) {
 
 function parseLine([lat, lng, weight]) {
   const location = new google.maps.LatLng(lat, lng);
-  bounds.extend(location);
   return { location, weight };
 }
 
@@ -149,14 +145,8 @@ function parseMapData(results, url) {
     maxIntensity: 30,
     opacity: 1
   });
-  bounds  = new google.maps.LatLngBounds();
   const heatmapData = filteredMapData(results);
   heatmap.setData(heatmapData);
-  if (fitToBounds) {
-    map.fitBounds(bounds);
-    map.panToBounds(bounds);
-    fitToBounds = false;
-  }
   heatmap.setMap(map);
   HEATMAPS[url] = url ? heatmap : undefined;
 }
@@ -196,8 +186,15 @@ function renderMap() {
 }
 
 function renderMapAndFit() {
-  fitToBounds = true;
   renderMap();
+  API.event(eventName)
+  .then(function (event) {
+    const SW = new google.maps.LatLng(event.bounding_box_coords[1], event.bounding_box_coords[0]);
+    const NE = new google.maps.LatLng(event.bounding_box_coords[3], event.bounding_box_coords[2])
+    const bounds  = new google.maps.LatLngBounds(SW, NE);
+    map.fitBounds(bounds);
+    map.panToBounds(bounds);
+  })
 }
 
 MAP_SELECT.addEventListener('change', renderMapAndFit);


### PR DESCRIPTION
Request the event details from the API, then use the event bounding box to set the map bounds.

Closes #23.