### PR TITLE
Fix Approve button

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -8,7 +8,7 @@ const API = {
     })
     .catch(function (error) {
       console.error(error);
-      return defaultValue;
+      return defaultValue;  //Return a default value, don't throw an error
     });
   },
   post: function(path, data) {
@@ -16,11 +16,12 @@ const API = {
     .send(data)
     .withCredentials()
     .then(function (response) {
-      return JSON.parse(response.text);
+      if (response.ok) return JSON.parse(response.text);
+      throw 'ERROR: can\'t Post';
     })
     .catch(function (error) {
       console.error(error);
-      return error;
+      throw error;  //Throw an error, let the calling function deal with the issue.
     });
   },
   approve: function (eventName, versionGroup) {

--- a/js/maps.js
+++ b/js/maps.js
@@ -40,6 +40,7 @@ function buildLayersMenu(layers) {
     .map(buildLayerGroup)
     .forEach(function (htmlGroup) { MAP_SELECT.appendChild(htmlGroup) });
 }
+
 function buildLayerGroup(versionGroup) {
   const htmlGroup = document.createElement('fieldset');
   htmlGroup.className = 'group';
@@ -65,34 +66,36 @@ function buildLayerGroup(versionGroup) {
     htmlApproveButton.textContent = 'Approve';
     htmlSubmenu.appendChild(htmlApproveButton);
 
-    htmlApproveButton.onclick = function() {
+    htmlApproveButton.onclick = function (e) {
       htmlApproveButton.textContent = 'Approving...';
-      htmlApproveButton.onclick = undefined;
+      htmlApproveButton.onclick = function (e2) { e2 && e2.preventDefault(); return false };  //Cancel out the approve button
 
       API.approve(eventName, versionGroup.version)
         .then(function (res) {
-          if (!res.ok) {
-            throw 'General Error - server returned ' + res.status;
-          }
           htmlApproveButton.textContent = 'DONE!';
         })
         .catch(function (err) {
           console.error(err);
           htmlApproveButton.textContent = 'ERROR';
         });
+      
+      e && e.preventDefault();
+      return false;
     };
   }
 
   versionGroup.layers
-    .map(buildLayerInput)
+    .map(function(layer) { return buildLayerInput(layer, versionGroup) })
     .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
 
   return htmlGroup;
 }
-function buildLayerInput(layer) {
+
+function buildLayerInput(layer, group) {
+  const layerName = layer.name;
   const option = document.createElement('label');
   const checkbox = document.createElement('input');
-  const text = document.createTextNode(layer.name)
+  const text = document.createTextNode(layerName)
   checkbox.type='checkbox';
   checkbox.value = layer.url;
   checkbox.checked = true;


### PR DESCRIPTION
## PR Overview

**Issue:** clicking on the "Approve" button of an Event Group (when viewing Pending Layers) will cause the page to navigate instead of submitting an 'approve' request to the API.

**Diagnosis:** the Approve button was attempting to submit the form.

**Solution:** a simple `clickEvent.preventDefault()` sorts the issue of the default 'submit' action taking place.

Note: clicking on the "Approve" button when it's in the pending ("Approving...") or complete ("Approved!" or "ERROR") states will no longer cause the form to submit either.

### Status

Merging this quick fix.