### PR TITLE
Add Metadata

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -8,7 +8,7 @@ const API = {
     })
     .catch(function (error) {
       console.error(error);
-      return defaultValue;  //Return a default value, don't throw an error
+      return defaultValue;  // Return a default value, don't throw an error
     });
   },
   post: function(path, data) {
@@ -21,7 +21,7 @@ const API = {
     })
     .catch(function (error) {
       console.error(error);
-      throw error;  //Throw an error, let the calling function deal with the issue.
+      throw error;  // Throw an error, let the calling function deal with the issue.
     });
   },
   approve: function (eventName, versionGroup) {
@@ -31,7 +31,19 @@ const API = {
     return API.get('/events', []);
   },
   layers: function (eventName) {
-    return API.get(`/layers/${eventName}`, []);
+    return API.get(`/layers/${eventName}`, [])
+    .then(function (layers) {  // Now fetch metadata for each layer group
+      console.log('+++ LAYERS: ', layers);
+      
+      return Promise.all(layers.map(function (layer) {
+        return Promise.resolve(layer);
+      })).then(function (data) {
+        console.log('+++ And the end result was... ', data);
+        
+        return data;
+      });
+
+    });
   },
   layer: function (eventName, layerName) {
     return API.get(`/layers/${eventName}/${layerName}`, []);

--- a/js/api.js
+++ b/js/api.js
@@ -36,12 +36,25 @@ const API = {
       console.log('+++ LAYERS: ', layers);
       
       return Promise.all(layers.map(function (layer) {
-        return Promise.resolve(layer);
-      })).then(function (data) {
-        console.log('+++ And the end result was... ', data);
         
-        return data;
-      });
+        function mergeLayerAndMetadata(metadata = null) {
+          layer.metadata = metadata; 
+          return layer;
+        }
+        
+        return superagent.get(layer.metadata_url)
+        .then(function (response) {
+          if (response.ok) return JSON.parse(response.text);
+          throw 'ERROR: can\'t get metadata';
+        })
+        .then(function (metadata) {
+          console.log('+++ metadata:', metadata);
+          return mergeLayerAndMetadata(metadata);
+        })
+        .catch(function (err) {
+          return mergeLayerAndMetadata();
+        });
+      }));  // This chain returns the layers, merged with their respective metadata.
 
     });
   },

--- a/js/maps.js
+++ b/js/maps.js
@@ -43,6 +43,7 @@ function buildLayersMenu(layers) {
 
 function buildLayerGroup(versionGroup) {
   const htmlGroup = document.createElement('fieldset');
+  htmlGroup.id = versionGroup.version;
   htmlGroup.className = 'group';
 
   const htmlHeader = document.createElement('legend');
@@ -85,22 +86,23 @@ function buildLayerGroup(versionGroup) {
   }
 
   versionGroup.layers
-    .map(function(layer) { return buildLayerInput(layer, versionGroup) })
+    .map(buildLayerInput)
     .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
 
   return htmlGroup;
 }
 
-function buildLayerInput(layer, group) {
-  const layerName = layer.name;
+function buildLayerInput(layer) {
   const option = document.createElement('label');
   const checkbox = document.createElement('input');
-  const text = document.createTextNode(layerName)
+  const span = document.createElement('span');
+  span.textContent = layer.name;
   checkbox.type='checkbox';
   checkbox.value = layer.url;
   checkbox.checked = true;
   option.appendChild(checkbox)
-  option.appendChild(text);
+  option.appendChild(span);
+  option.id = layer.name;
   return option;
 }
 

--- a/js/maps.js
+++ b/js/maps.js
@@ -47,7 +47,6 @@ function buildLayerGroup(versionGroup) {
   htmlGroup.className = 'group';
 
   const htmlHeader = document.createElement('legend');
-  console.log('+++', versionGroup)
   htmlHeader.textContent = (versionGroup.metadata && versionGroup.metadata.AOI)
     ? versionGroup.metadata.AOI
     : versionGroup.version;
@@ -89,17 +88,23 @@ function buildLayerGroup(versionGroup) {
   }
 
   versionGroup.layers
-    .map(buildLayerInput)
+    .map(function (layer) { return buildLayerInput(layer, versionGroup) })
     .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
 
   return htmlGroup;
 }
 
-function buildLayerInput(layer) {
+function buildLayerInput(layer, versionGroup) {
+  const layerMetadata = (versionGroup && versionGroup.metadata && versionGroup.metadata.layers)
+    ? versionGroup.metadata.layers.find(function (layermeta) { return layer.url.endsWith(`/${layermeta.file_name}`) })
+    : undefined;
+  
   const option = document.createElement('label');
   const checkbox = document.createElement('input');
   const span = document.createElement('span');
-  span.textContent = layer.name;
+  span.textContent = (layerMetadata && layerMetadata.description)
+    ? layerMetadata.description
+    : layer.name;
   checkbox.type='checkbox';
   checkbox.value = layer.url;
   checkbox.checked = true;

--- a/js/maps.js
+++ b/js/maps.js
@@ -47,7 +47,10 @@ function buildLayerGroup(versionGroup) {
   htmlGroup.className = 'group';
 
   const htmlHeader = document.createElement('legend');
-  htmlHeader.textContent = versionGroup.version;
+  console.log('+++', versionGroup)
+  htmlHeader.textContent = (versionGroup.metadata && versionGroup.metadata.AOI)
+    ? versionGroup.metadata.AOI
+    : versionGroup.version;
   htmlGroup.appendChild(htmlHeader);
 
   const htmlSubmenu = document.createElement('div');


### PR DESCRIPTION
## PR Overview

Partially addresses #34 

With this PR, the map now fetches the `metadata` file of each Layer Group (aka Version Group aka Layers) and uses the metadata to populate the UI with more useful information.

The changes in this PR are notable:
- API: after fetching the Layer Groups, the metadata file of **each layer group** is then fetched (⚠️ possible leading to multiple simultaneous requests for metadata) and then **merged into the returning layers object**
- Map: using this metadata, the Layer Group is now labelled with its description (e.g. "v5" now shows as "St John" on the map controls) and each sublayer/CSV cluster now explains the content of that sublayer (e.g. "st_john_overlay_4.csv" now says "Building Damage")

![Screen Shot 2019-04-26 at 18 35 18](https://user-images.githubusercontent.com/13952701/56825935-a36dcd80-6852-11e9-8cd1-0967a9d50a19.png)

NOT in this PR, but were requested by #34:
- Anything to do with `metadata.legends`, because I still haven't grokked how something like `["20 to 40% damage", "40 to 80% damage", "above 80% damage"]` corresponds to arbitrary values like `2, 3, 5` without having some sort of arbitrary mapping.

### Status
Merging!