### PR TITLE
UI Improvements - Legends and Toggle Group

### DIFF
--- a/css/map-page.css
+++ b/css/map-page.css
@@ -46,6 +46,8 @@
   padding: 0;
   margin: 0 0 0 2em;
 }
+.layer-control-legends li.selected { color: #c84; }
+.layer-control-legends li.unselected { color: #ccc; }
 
 #map-filters {
   flex: 0 0 auto;

--- a/css/map-page.css
+++ b/css/map-page.css
@@ -38,6 +38,15 @@
 #map-select .submenu .metadata-link {}
 #map-select .submenu .approve-button {}
 
+.layer-control-legends {
+  padding: 0; margin: 0;
+  font-size: 0.8em;
+}
+.layer-control-legends li {
+  padding: 0;
+  margin: 0 0 0 2em;
+}
+
 #map-filters {
   flex: 0 0 auto;
   padding: 0 1em;

--- a/js/maps.js
+++ b/js/maps.js
@@ -124,6 +124,8 @@ function buildLayerGroup(layerGroup) {
     const anySelected = !!checkboxes.find(function (checkbox) { return checkbox.checked });
     checkboxes.forEach(function (checkbox) { checkbox.checked = !anySelected });
     
+    toggleMultipleLayers(version);
+    
     e && e.preventDefault();
     return false;
   };
@@ -161,14 +163,12 @@ function buildLayerInput(layer, layerGroup) {
   if (legends && legends.length > 0) {
     const ol = document.createElement('ol');
     ol.className = 'layer-control-legends';
-    
     legends.forEach(function (legend, index) {
       const li = document.createElement('li');
       li.textContent = legend;
       li.dataset.legendValue = index + 1;
       ol.appendChild(li);
     });
-    
     div.appendChild(ol);
   }
   
@@ -245,6 +245,33 @@ function toggleLayer(event) {
   }
 }
 
+function toggleMultipleLayers(layerGroupVersion) {
+  const checkboxes = Array.from(document.querySelectorAll(`.layer-control[data-group='${layerGroupVersion}'] input[type='checkbox']`));
+  
+  checkboxes.forEach(function (checkbox) {
+    const url = checkbox.value;
+    if (checkbox.checked) {
+      if (HEATMAPS[url]) {
+        HEATMAPS[url].setMap(GOOGLE_MAP);
+      } else {
+        readMapFile(url);
+      }
+    } else {
+      HEATMAPS[url] && HEATMAPS[url].setMap(null);
+    }
+  });
+  
+  /*if (event.target.checked) {
+    if (HEATMAPS[url]) {
+      HEATMAPS[url].setMap(GOOGLE_MAP);
+    } else {
+      readMapFile(url);
+    }
+  } else {
+    HEATMAPS[url] && HEATMAPS[url].setMap(null);
+  }*/
+}
+
 function renderMap(resolveFunc) {
   const urls = Object.keys(HEATMAPS);
   urls.forEach(function (url) {
@@ -274,7 +301,6 @@ function updateMapControlsUI () {
     Array.from(selectedElements).forEach(function (element) {
       if (val >= threshold) element.className = 'selected';
       else element.className = 'unselected';
-      console.log(element);
     });
   }
 }
@@ -307,7 +333,6 @@ function zoomToFit() {
     });
   GOOGLE_MAP.fitBounds(bounds);
   GOOGLE_MAP.panToBounds(bounds);
-
 }
 
 MAP_SELECT.addEventListener('change', toggleLayer);

--- a/js/maps.js
+++ b/js/maps.js
@@ -245,6 +245,22 @@ function renderMap(resolveFunc) {
         readMapFile(url, resolveFunc);
       }
     })
+  updateMapControlsUI();
+}
+
+function updateMapControlsUI () {
+  const threshold = parseInt(MAP_THRESHOLD.value);
+  const thresholdMin = Number.parseInt(MAP_THRESHOLD.min);
+  const thresholdMax = Number.parseInt(MAP_THRESHOLD.max);
+  
+  for (let val = thresholdMin; val <= thresholdMax; val++) {
+    const selectedElements = document.querySelectorAll(`.layer-control-legends li[data-legend-value='${val}']`);
+    Array.from(selectedElements).forEach(function (element) {
+      if (val >= threshold) element.className = 'selected';
+      else element.className = 'unselected';
+      console.log(element);
+    });
+  }
 }
 
 function FitEventBounds() {

--- a/js/maps.js
+++ b/js/maps.js
@@ -143,9 +143,20 @@ function buildLayerInput(layer, layerGroup) {
     ? HEATMAP_GROUPS[layerGroup.version].layers[layer.url].legend
     : [];
   if (legends && legends.length > 0) {
-    // TODO
+    const ol = document.createElement('ol');
+    ol.className = 'layer-control-legends';
+    
+    legends.forEach(function (legend, index) {
+      const li = document.createElement('li');
+      li.textContent = legend;
+      li.dataset.legendValue = index + 1;
+      ol.appendChild(li);
+    });
+    
+    div.appendChild(ol);
   }
   
+  div.className = 'layer-control';
   div.dataset.group = layerGroup.version;
   div.dataset.layer = layer.name;
   div.dataset.url = layer.url;

--- a/js/maps.js
+++ b/js/maps.js
@@ -211,7 +211,7 @@ function parseMapData(results, url) {
   });
   const heatmapData = filteredMapData(results);
   heatmap.setData(heatmapData);
-  heatmap.setMap(map);
+  heatmap.setMap(GOOGLE_MAP);
   HEATMAPS[url] = url ? heatmap : undefined;
 }
 
@@ -236,7 +236,7 @@ function toggleLayer(event) {
   const url = event.target.value;
   if (event.target.checked) {
     if (HEATMAPS[url]) {
-      HEATMAPS[url].setMap(map);
+      HEATMAPS[url].setMap(GOOGLE_MAP);
     } else {
       readMapFile(url);
     }
@@ -256,7 +256,7 @@ function renderMap(resolveFunc) {
       if (HEATMAPS[url]) {
         const heatmapData = filteredMapData(HEATMAP_DATA[url]);
         HEATMAPS[url].setData(heatmapData);
-        HEATMAPS[url].setMap(map);
+        HEATMAPS[url].setMap(GOOGLE_MAP);
       } else {
         readMapFile(url, resolveFunc);
       }
@@ -287,8 +287,8 @@ function FitEventBounds() {
       const SW = new google.maps.LatLng(boundingBoxCoords[1], boundingBoxCoords[0]);
       const NE = new google.maps.LatLng(boundingBoxCoords[3], boundingBoxCoords[2]);
       const bounds  = new google.maps.LatLngBounds(SW, NE);
-      map.fitBounds(bounds);
-      map.panToBounds(bounds);
+      GOOGLE_MAP.fitBounds(bounds);
+      GOOGLE_MAP.panToBounds(bounds);
     } else {
       console.log(event);
     }
@@ -305,8 +305,8 @@ function zoomToFit() {
         bounds.extend(point.location);
       });
     });
-  map.fitBounds(bounds);
-  map.panToBounds(bounds);
+  GOOGLE_MAP.fitBounds(bounds);
+  GOOGLE_MAP.panToBounds(bounds);
 
 }
 
@@ -315,7 +315,7 @@ MAP_THRESHOLD.addEventListener('change', renderMap);
 ZOOM_TO_FIT.addEventListener('click', zoomToFit);
 
 const center = new google.maps.LatLng(15.231458142, -61.2507115);
-const map = new google.maps.Map(MAP_CONTAINER, Object.assign(MAP_OPTIONS, { center }));
+const GOOGLE_MAP = new google.maps.Map(MAP_CONTAINER, Object.assign(MAP_OPTIONS, { center }));
 
 const eventName = queryParams().event;
 const pendingLayers = queryParams().pending;

--- a/js/maps.js
+++ b/js/maps.js
@@ -112,6 +112,22 @@ function buildLayerGroup(layerGroup) {
   layerGroup.layers
     .map(function (layer) { return buildLayerInput(layer, layerGroup) })
     .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
+  
+  // Add toggle option
+  const htmlToggle = document.createElement('button');
+  htmlToggle.textContent = 'Toggle group';
+  htmlToggle.onclick = function (e) {
+    const version = layerGroup.version;
+    const checkboxes = Array.from(document.querySelectorAll(`.layer-control[data-group='${version}'] input[type='checkbox']`));
+
+    //If any checkboxes are checked, uncheck them all. Otherwise, check them all.
+    const anySelected = !!checkboxes.find(function (checkbox) { return checkbox.checked });
+    checkboxes.forEach(function (checkbox) { checkbox.checked = !anySelected });
+    
+    e && e.preventDefault();
+    return false;
+  };
+  htmlGroup.appendChild(htmlToggle);
 
   return htmlGroup;
 }
@@ -138,7 +154,7 @@ function buildLayerInput(layer, layerGroup) {
   option.appendChild(span);
   div.appendChild(option);
   
-  //Add legends, if any.
+  // Add legends, if any.
   const legends = (HEATMAP_GROUPS[layerGroup.version] && HEATMAP_GROUPS[layerGroup.version].layers[layer.url])
     ? HEATMAP_GROUPS[layerGroup.version].layers[layer.url].legend
     : [];


### PR DESCRIPTION
## PR Overview

This PR adds some quality-of-life UI improvements to the map. Closes #35 , closes #34  

- A new "Toggle Group" button has been added to enable/disable multiple layers in a group at once.
- A map Legend has been added to the layers where severity levels have any sort of meaning. (e.g. the "Building destruction" layer)
  - When the _threshold_ is adjusted, the map legend changes to indicate what level of severity is being shown. e.g. if threshold is set to 3 (see image below), the legends for _"severity 3 - 40-80% damage"_ and _"severity 4 - above 80% damage"_ are highlighted in orange.

![Screen Shot 2019-05-16 at 19 54 33](https://user-images.githubusercontent.com/13952701/57879503-8e160e80-7814-11e9-925e-e7cb43e5b64e.png)
_Toggle button and map legend showing for the caribbean_2018_demo event._

### Status

I'm going ahead and merging this. @camallen this update may be of interest to you; we can talk tomorrow if there are any features that are still missing.