### PR TITLE
use ES6 modules for API code

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,5 +8,5 @@
   </ul>
 </main>
 <script src="/js/superagent.js"></script>
-<script src="/js/api.js"></script>
-<script src="/js/events.js"></script>
+<script type="module" src="/js/api.js"></script>
+<script type="module" src="/js/events.js"></script>

--- a/js/api.js
+++ b/js/api.js
@@ -67,6 +67,4 @@ const API = {
   },
 }
 
-export function api() {
-  return API;
-};
+export { API };

--- a/js/api.js
+++ b/js/api.js
@@ -48,7 +48,7 @@ const API = {
     return Promise.all(layers.map(function (layer) {
 
       function mergeLayerAndMetadata(metadata = null) {
-        layer.metadata = metadata; 
+        layer.metadata = metadata;
         return layer;
       }
 
@@ -64,6 +64,9 @@ const API = {
         return mergeLayerAndMetadata();
       });
     }));  // This chain returns the layers, merged with their respective metadata.
-
   },
 }
+
+export function api() {
+  return API;
+};

--- a/js/api.js
+++ b/js/api.js
@@ -1,4 +1,4 @@
-const API = {
+export const API = {
   host: 'https://maps-api.planetaryresponsenetwork.org',
   get: function(path, defaultValue) {
     return superagent.get(`${API.host}${path}`)
@@ -66,5 +66,3 @@ const API = {
     }));  // This chain returns the layers, merged with their respective metadata.
   },
 }
-
-export { API };

--- a/js/events.js
+++ b/js/events.js
@@ -1,4 +1,4 @@
-import { api } from './api.js';
+import { API } from './api.js';
 
 const EVENTS_LIST = document.getElementById('events');
 function createAnchor(href, textContent) {
@@ -31,5 +31,5 @@ function listEvents(events) {
     });
 }
 
-api().events()
+API.events()
 .then(listEvents)

--- a/js/events.js
+++ b/js/events.js
@@ -1,3 +1,5 @@
+import { api } from './api.js';
+
 const EVENTS_LIST = document.getElementById('events');
 function createAnchor(href, textContent) {
   const link = document.createElement('a');
@@ -11,7 +13,7 @@ function buildEventLinks(event) {
   const uploadHref = "/maps/upload.html?event=" + event.name;
   const eventLink = createAnchor(eventHref, event.name);
   const pendingLink = createAnchor(pendingHref, "pending layers");
-  const uploadLink = createAnchor(uploadHref, "upload layers"); 
+  const uploadLink = createAnchor(uploadHref, "upload layers");
   const item = document.createElement('li')
   item.appendChild(eventLink);
   item.appendChild(document.createTextNode(' '));
@@ -29,5 +31,5 @@ function listEvents(events) {
     });
 }
 
-API.events()
+api().events()
 .then(listEvents)

--- a/js/maps.js
+++ b/js/maps.js
@@ -1,5 +1,5 @@
 import { queryParams } from './queryParams.js';
-import { api } from './api.js';
+import { API } from './api.js';
 
 const MAP_CONTAINER = document.getElementById('map');
 const MAP_THRESHOLD = document.getElementById('map-threshold');
@@ -97,7 +97,7 @@ function buildLayerGroup(layerGroup) {
       htmlApproveButton.textContent = 'Approving...';
       htmlApproveButton.onclick = function (e2) { e2 && e2.preventDefault(); return false };  //Cancel out the approve button
 
-      api().approve(eventName, layerGroup.version)
+      API.approve(eventName, layerGroup.version)
         .then(function (res) {
           htmlApproveButton.textContent = 'DONE!';
         })
@@ -308,7 +308,7 @@ function updateMapControlsUI () {
 }
 
 function FitEventBounds() {
-  api().event(eventName)
+  API.event(eventName)
   .then(function (event) {
     const boundingBoxCoords = event.bounding_box_coords;
     if (boundingBoxCoords) {
@@ -357,7 +357,7 @@ if (pendingLayers) {
   getLayerFunc = 'layer';
 }
 
-api()[getLayerFunc](eventName, layer)
+API[getLayerFunc](eventName, layer)
   .then(buildLayersMenu)
   .then(function () {
     if (layer) {

--- a/js/maps.js
+++ b/js/maps.js
@@ -36,7 +36,6 @@ const VISIBLE_WEIGHT_EXPONENT = 2.5;
 function buildLayersMenu(layerGroups) {
   // Record data in global store.
   HEATMAP_GROUPS = {};
-  console.log(layerGroups)
   layerGroups.forEach(function (group) {
     let layers = {};
     group.layers.forEach(function (layer, index) {

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,5 +1,5 @@
 import { queryParams } from './queryParams.js';
-import { api } from './api.js';
+import { API } from './api.js';
 
 const htmlUploadForm = document.getElementById('upload-form');
 const htmlEventList = document.getElementById('event-list');
@@ -10,7 +10,7 @@ const htmlSubmitButton = document.getElementById('submit-button');
 
 function updateFormAction() {
   const eventName = htmlEventList.value;
-  const url = api().host + '/upload/layers/' + eventName;
+  const url = API.host + '/upload/layers/' + eventName;
   htmlUploadForm.action = url;
 
   htmlStatusText.textContent = 'Files will be uploaded to ' + eventName;
@@ -73,7 +73,7 @@ function submit() {
 htmlSubmitButton.onclick = submit;
 
 // Fetch list of Map Events
-api().events().then(updateEventsList)
+API.events().then(updateEventsList)
 htmlEventList.onchange = updateFormAction;
 
 // GO!

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,4 +1,5 @@
-import { queryParams } from './queryParams.js'
+import { queryParams } from './queryParams.js';
+import { api } from './api.js';
 
 const htmlUploadForm = document.getElementById('upload-form');
 const htmlEventList = document.getElementById('event-list');
@@ -9,7 +10,7 @@ const htmlSubmitButton = document.getElementById('submit-button');
 
 function updateFormAction() {
   const eventName = htmlEventList.value;
-  const url = API.host + '/upload/layers/' + eventName;
+  const url = api().host + '/upload/layers/' + eventName;
   htmlUploadForm.action = url;
 
   htmlStatusText.textContent = 'Files will be uploaded to ' + eventName;
@@ -72,7 +73,7 @@ function submit() {
 htmlSubmitButton.onclick = submit;
 
 // Fetch list of Map Events
-API.events().then(updateEventsList)
+api().events().then(updateEventsList)
 htmlEventList.onchange = updateFormAction;
 
 // GO!

--- a/maps/index.html
+++ b/maps/index.html
@@ -38,5 +38,5 @@
 <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAuB-Cc3bS2NYFnAKiNa-6lrE0g70wFh6c&libraries=visualization"></script>
 <script src="/js/superagent.js"></script>
 <script src="/js/papaparse.min.js"></script>
-<script src="/js/api.js"></script>
+<script type="module" src="/js/api.js"></script>
 <script type="module" src="/js/maps.js"></script>

--- a/maps/upload.html
+++ b/maps/upload.html
@@ -10,7 +10,7 @@
       <select id="event-list" name="event-list"></select>
     </div>
   </section>
-  
+
   <form id="upload-form" method="post" action="#" enctype="multipart/form-data">
     <div class="row">
       <label for="metadata-file">Metadata File (JSON)</label>
@@ -30,5 +30,5 @@
 </main>
 
 <script src="/js/superagent.js"></script>
-<script src="/js/api.js"></script>
+<script type="module" src="/js/api.js"></script>
 <script type="module" src="/js/upload.js"></script>


### PR DESCRIPTION
Fixes the issue of the app not working on safari. 

Avoid module race condition loads for modules, i.e. API wasn't defined when referencing in the module script.

Noting that the protected API routes, pending / upload, etc still do not work on safari as the basic auth protected API requests simply fail in safari only. Switching to use the manual auth code in superagent works fine though
```
get: function(path, defaultValue) {
    return superagent.get(`${API.host}${path}`)
    .auth('username', 'password')
    .then(function (response) {
      return JSON.parse(response.text);
    })
    .catch(function (error) {
      console.error(error);
      return defaultValue;  // Return a default value, don't throw an error
    });
  },
```

I can't find a reason why this is the case on my safari version, thoughts / help appreciated.

