### PR TITLE
Jun 2019 update - refactor into MapApp, single layer view, each layer has a colour

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -6,8 +6,9 @@ body {
   font-family: sans-serif;
   background: #fffefd;
   color: #000102;
-  margin: .5em;
-  font-size: .9em;
+  padding: 0;
+  margin: 0;
+  font-size: 14px;
   line-height: 1.5;
 }
 

--- a/js/maps.js
+++ b/js/maps.js
@@ -193,8 +193,6 @@ class MapApp {
       .map(this.buildMapControls_groupHtml.bind(this))
       .forEach((htmlGroup) => { HTML_MAP_SELECT.appendChild(htmlGroup) });
     
-    console.log('+++ buildMapControls');
-    
     // Select the first layer by default
     const defaultLayer = selectAllLayers()[0];
     defaultLayer && window.mapApp.activateLayer(defaultLayer);

--- a/js/maps.js
+++ b/js/maps.js
@@ -21,6 +21,7 @@ var HEATMAP_GROUPS = {};
 // The dots are more visible on the map with a higher weight.
 const VISIBLE_WEIGHT_MULTIPLIER = 1;
 const VISIBLE_WEIGHT_EXPONENT = 2;
+const MAX_INTENSITY = 5;
 
 function minimumWeight([lat, lng, weight]) {
   const threshold = parseInt(MAP_THRESHOLD.value);
@@ -55,7 +56,7 @@ function parseMapData (results, url) {
   // For each heatmap, assign a preset colour to it.
   const heatmap = new google.maps.visualization.HeatmapLayer({
     gradient: layer.gradient,
-    maxIntensity: 5,  // TODO: change level of maxIntensity based on metadata
+    maxIntensity: MAX_INTENSITY,  // TODO: change level of maxIntensity based on metadata
     opacity: 1
   });
   layer.heatmap = heatmap;

--- a/js/maps.js
+++ b/js/maps.js
@@ -17,13 +17,6 @@ const MAP_OPTIONS = {
 }
 
 var HEATMAP_GROUPS = {};
-const HEATMAP_DATA = {};
-
-// Pre-set colour gradients - provides the best contrast on a predominantly blue-green map.
-// The first step in each gradient must be fully transparent, to indicate the 0-value.
-let HEATMAP_GRADIENT = [  
-  'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)',
-];
 
 // The dots are more visible on the map with a higher weight.
 const VISIBLE_WEIGHT_MULTIPLIER = 1;
@@ -67,8 +60,6 @@ function parseMapData (results, url) {
   });
   layer.heatmap = heatmap;
   
-  // TODO: change to HEATMAP_GROUPS
-  
   const heatmapData = filteredMapData(results);
   heatmap.setData(heatmapData);
   heatmap.setMap(GOOGLE_MAP);
@@ -79,7 +70,7 @@ function cacheMapData (results, file) {
   const { group, layer } = selectLayerByUrl(url);
   if (!layer) return;
   
-  HEATMAP_DATA[url] = url ? results : undefined;
+  layer.csvData = results;
   parseMapData(results, url);
 }
 
@@ -402,7 +393,7 @@ class MapApp {
         const { group, layer } = selectLayerByUrl(url);
       
         if (layer && layer.heatmap) {
-          const heatmapData = filteredMapData(HEATMAP_DATA[url]);
+          const heatmapData = filteredMapData(layer.csvData);
           layer.heatmap.setData(heatmapData);
           layer.heatmap.setMap(GOOGLE_MAP);
         } else {

--- a/js/maps.js
+++ b/js/maps.js
@@ -49,6 +49,15 @@ function selectLayerByUrl (url) {
   return { group, layer };
 }
 
+function selectAllLayers () {
+  return Object.values(HEATMAP_GROUPS)
+    .map(group => {
+      return (group.layers && Object.values(group.layers))
+        || []
+    })
+    .flat();
+}
+
 function parseMapData (results, url) {
   const { group, layer } = selectLayerByUrl(url);
   if (!layer) return;
@@ -102,20 +111,14 @@ function fitEventBounds() {
   })
 }
 
-function zoomToFit() {
+function zoomToFit () {
   const bounds  = new google.maps.LatLngBounds();
-  
-  // TODO: fix ZoomToFit
-  
-  /* MAP_SELECT_FORM.querySelectorAll('input:checked')
-    .forEach(function (node) {
-      const url = node.value;
-      const { group, layer } = selectLayerByUrl(url);
-      const data = layer.heatmap && layer.heatmap.getData();
-      data.forEach(function (point) {
-        bounds.extend(point.location);
-      });
-    });*/
+  selectAllLayers().forEach(function (layer) {
+    const data = layer.show && layer.heatmap && layer.heatmap.getData() || [];
+    data.forEach(function (point) {
+      bounds.extend(point.location);
+    });
+  });
   GOOGLE_MAP.fitBounds(bounds);
   GOOGLE_MAP.panToBounds(bounds);
 }

--- a/js/maps.js
+++ b/js/maps.js
@@ -20,17 +20,16 @@ var HEATMAP_GROUPS = {};
 const HEATMAPS = {};
 const HEATMAP_DATA = {};
 
-let HEATMAP_GRADIENT = [  // Pre-set colour gradient - provides the best contrast on a predominantly blue-green map.
-  'rgba(255, 0, 0, 0.0)',  // Transparency required as first step to indicate 0-value
-  'rgba(255, 0, 0, 0.5)',  // First step should be at opacity 1.0 so points will be visible at full zoom.
-  'rgba(255, 64, 0, 0.5)',
-  'rgba(255, 128, 0, 0.5)',
-  'rgba(255, 192, 32, 0.5)',
-  'rgba(255, 255, 64, 0.5)',
+// Pre-set colour gradients - provides the best contrast on a predominantly blue-green map.
+// The first step in each gradient must be fully transparent, to indicate the 0-value.
+let HEATMAP_GRADIENT = [  
+  'rgba(255, 255, 0, 0.0)',
+  'rgba(255, 255, 0, 0.5)',
 ];
 
-const VISIBLE_WEIGHT_MULTIPLIER = 5;  // The dots are more visible on the map with a higher weight.
-const VISIBLE_WEIGHT_EXPONENT = 2.5;
+// The dots are more visible on the map with a higher weight.
+const VISIBLE_WEIGHT_MULTIPLIER = 1;
+const VISIBLE_WEIGHT_EXPONENT = 2;
 
 function buildLayersMenu(layerGroups) {
   // Record data in global store.
@@ -355,13 +354,24 @@ if (pendingLayers) {
   getLayerFunc = 'layer';
 }
 
-API[getLayerFunc](eventName, layer)
-  .then(buildLayersMenu)
-  .then(function () {
-    if (layer) {
-      renderMap(zoomToFit);
-    } else {
-      renderMap();
-      FitEventBounds();
-    }
-  });
+
+class MapApp {
+  constructor () {
+    this.fetchMapData();
+  }
+
+  fetchMapData () {
+    API[getLayerFunc](eventName, layer)
+    .then(buildLayersMenu)
+    .then(function () {
+      if (layer) {
+        renderMap(zoomToFit);
+      } else {
+        renderMap();
+        FitEventBounds();
+      }
+    });
+  }
+}
+
+window.mapApp = new MapApp();

--- a/js/maps.js
+++ b/js/maps.js
@@ -325,22 +325,19 @@ class MapApp {
   
   renderMap (resolveFunction) {
     // For each map, show/hide them as necessary.
-    Object.values(HEATMAP_GROUPS)
-      .forEach((group) => {
-        group.layers && Object.values(group.layers).forEach((layer) => {
-          if (!layer.show) {
-            layer.heatmap && layer.heatmap.setMap(null);
-          } else {
-            if (layer && layer.heatmap) {
-              const heatmapData = filteredMapData(layer.csvData);
-              layer.heatmap.setData(heatmapData);
-              layer.heatmap.setMap(GOOGLE_MAP);
-            } else {
-              readMapFile(layer.url, resolveFunction);
-            }
-          }
-        });
-      });
+    selectAllLayers().forEach((layer) => {
+      if (!layer.show) {
+        layer.heatmap && layer.heatmap.setMap(null);
+      } else {
+        if (layer && layer.heatmap) {
+          const heatmapData = filteredMapData(layer.csvData);
+          layer.heatmap.setData(heatmapData);
+          layer.heatmap.setMap(GOOGLE_MAP);
+        } else {
+          readMapFile(layer.url, resolveFunction);
+        }
+      }
+    });
     this.updateMapControlsUI();
   }
   
@@ -365,12 +362,7 @@ class MapApp {
   }
   
   deactivateAllLayers () {
-    Object.values(HEATMAP_GROUPS)
-      .forEach((group) => {
-        group.layers && Object.values(group.layers).forEach((layer) => {
-          layer.show = false;
-        });
-      });
+    selectAllLayers().forEach((layer) => { layer.show = false; });
   }
 }
 

--- a/js/maps.js
+++ b/js/maps.js
@@ -30,56 +30,6 @@ let HEATMAP_GRADIENT = [
 const VISIBLE_WEIGHT_MULTIPLIER = 1;
 const VISIBLE_WEIGHT_EXPONENT = 2;
 
-function buildLayerGroup(layerGroup) {
-  
-}
-
-function buildLayerInput(layer, layerGroup) {
-  const layerMetadata = (layerGroup && layerGroup.metadata && layerGroup.metadata.layers)
-    ? layerGroup.metadata.layers.find(function (layermeta) { return layer.url.endsWith(`/${layermeta.file_name}`) })
-    : undefined;
-  
-  const div = document.createElement('div');
-  const option = document.createElement('label');
-  const checkbox = document.createElement('input');
-  const span = document.createElement('span');
-  
-  span.textContent = (layerMetadata && layerMetadata.description)
-    ? layerMetadata.description
-    : layer.name;
-  
-  checkbox.type='checkbox';
-  checkbox.value = layer.url;
-  checkbox.checked = true;
-  
-  option.appendChild(checkbox)
-  option.appendChild(span);
-  div.appendChild(option);
-  
-  // Add legends, if any.
-  const legends = (HEATMAP_GROUPS[layerGroup.version] && HEATMAP_GROUPS[layerGroup.version].layers[layer.url])
-    ? HEATMAP_GROUPS[layerGroup.version].layers[layer.url].legend
-    : [];
-  if (legends && legends.length > 0) {
-    const ol = document.createElement('ol');
-    ol.className = 'layer-control-legends';
-    legends.forEach(function (legend, index) {
-      const li = document.createElement('li');
-      li.textContent = legend;
-      li.dataset.legendValue = index + 1;
-      ol.appendChild(li);
-    });
-    div.appendChild(ol);
-  }
-  
-  div.className = 'layer-control';
-  div.dataset.group = layerGroup.version;
-  div.dataset.layer = layer.name;
-  div.dataset.url = layer.url;
-  
-  return div;
-}
-
 function minimumWeight([lat, lng, weight]) {
   const threshold = parseInt(MAP_THRESHOLD.value);
   return weight >= threshold;
@@ -296,7 +246,7 @@ class MapApp {
     });
     
     Object.values(HEATMAP_GROUPS)
-      .map(this.buildMapControls_layerGroups)
+      .map(this.buildMapControls_layerGroups.bind(this))
       .forEach(function (htmlGroup) { MAP_SELECT.appendChild(htmlGroup) });
   }
   
@@ -347,7 +297,7 @@ class MapApp {
     }
 
     Object.values(layerGroup.layers)
-      .map(function (layer) { return buildLayerInput(layer, layerGroup) })
+      .map(function (layer) { return this.buildMapControls_individual(layer, layerGroup) }.bind(this))
       .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
 
     // Add toggle option
@@ -369,6 +319,52 @@ class MapApp {
     htmlGroup.appendChild(htmlToggle);
 
     return htmlGroup;
+  }
+  
+  buildMapControls_individual (layer, layerGroup) {
+    const layerMetadata = (layerGroup && layerGroup.metadata && layerGroup.metadata.layers)
+      ? layerGroup.metadata.layers.find(function (layermeta) { return layer.url.endsWith(`/${layermeta.file_name}`) })
+      : undefined;
+
+    const div = document.createElement('div');
+    const option = document.createElement('label');
+    const checkbox = document.createElement('input');
+    const span = document.createElement('span');
+
+    span.textContent = (layerMetadata && layerMetadata.description)
+      ? layerMetadata.description
+      : layer.name;
+
+    checkbox.type='checkbox';
+    checkbox.value = layer.url;
+    checkbox.checked = true;
+
+    option.appendChild(checkbox)
+    option.appendChild(span);
+    div.appendChild(option);
+
+    // Add legends, if any.
+    const legends = (HEATMAP_GROUPS[layerGroup.version] && HEATMAP_GROUPS[layerGroup.version].layers[layer.url])
+      ? HEATMAP_GROUPS[layerGroup.version].layers[layer.url].legend
+      : [];
+    if (legends && legends.length > 0) {
+      const ol = document.createElement('ol');
+      ol.className = 'layer-control-legends';
+      legends.forEach(function (legend, index) {
+        const li = document.createElement('li');
+        li.textContent = legend;
+        li.dataset.legendValue = index + 1;
+        ol.appendChild(li);
+      });
+      div.appendChild(ol);
+    }
+
+    div.className = 'layer-control';
+    div.dataset.group = layerGroup.version;
+    div.dataset.layer = layer.name;
+    div.dataset.url = layer.url;
+
+    return div;
   }
   
   chooseLayerColour (index) {

--- a/js/maps.js
+++ b/js/maps.js
@@ -246,11 +246,11 @@ class MapApp {
     });
     
     Object.values(HEATMAP_GROUPS)
-      .map(this.buildMapControls_layerGroups.bind(this))
+      .map(this.buildMapControls_groupHtml.bind(this))
       .forEach(function (htmlGroup) { MAP_SELECT.appendChild(htmlGroup) });
   }
   
-  buildMapControls_layerGroups (layerGroup) {
+  buildMapControls_groupHtml (layerGroup) {
     const htmlGroup = document.createElement('fieldset');
     htmlGroup.id = layerGroup.version;
     htmlGroup.className = 'group';
@@ -297,7 +297,7 @@ class MapApp {
     }
 
     Object.values(layerGroup.layers)
-      .map(function (layer) { return this.buildMapControls_individual(layer, layerGroup) }.bind(this))
+      .map(function (layer) { return this.buildMapControls_layerHtml(layer, layerGroup) }.bind(this))
       .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
 
     // Add toggle option
@@ -321,13 +321,13 @@ class MapApp {
     return htmlGroup;
   }
   
-  buildMapControls_individual (layer, layerGroup) {
+  buildMapControls_layerHtml (layer, layerGroup) {
     const layerMetadata = (layerGroup && layerGroup.metadata && layerGroup.metadata.layers)
       ? layerGroup.metadata.layers.find(function (layermeta) { return layer.url.endsWith(`/${layermeta.file_name}`) })
       : undefined;
 
     const div = document.createElement('div');
-    const option = document.createElement('label');
+    const label = document.createElement('label');
     const checkbox = document.createElement('input');
     const span = document.createElement('span');
 
@@ -335,13 +335,14 @@ class MapApp {
       ? layerMetadata.description
       : layer.name;
 
-    checkbox.type='checkbox';
+    checkbox.type = 'checkbox';
     checkbox.value = layer.url;
     checkbox.checked = true;
 
-    option.appendChild(checkbox)
-    option.appendChild(span);
-    div.appendChild(option);
+    label.style.borderRight = `0.5em solid ${layer.colour}`;
+    label.appendChild(checkbox)
+    label.appendChild(span);
+    div.appendChild(label);
 
     // Add legends, if any.
     const legends = (HEATMAP_GROUPS[layerGroup.version] && HEATMAP_GROUPS[layerGroup.version].layers[layer.url])
@@ -371,16 +372,18 @@ class MapApp {
     const colours = [
       'rgba(255, 255, 0, 1.0)',
       'rgba(255, 0, 255, 1.0)',
+      'rgba(0, 255, 255, 1.0)',
     ];
-    return colours[Math.max(index, colours.length - 1)];
+    return colours[Math.min(index, colours.length - 1)];
   }
   
   chooseLayerGradient (index) {
     const colours = [
       [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)', ],
       [ 'rgba(255, 0, 255, 0.0)', 'rgba(255, 0, 255, 0.5)', ],
+      [ 'rgba(0, 255, 255, 0.0)', 'rgba(0, 255, 255, 0.5)', ],
     ];
-    return colours[Math.max(index, colours.length - 1)];
+    return colours[Math.min(index, colours.length - 1)];
   }
 }
 

--- a/js/maps.js
+++ b/js/maps.js
@@ -31,74 +31,7 @@ const VISIBLE_WEIGHT_MULTIPLIER = 1;
 const VISIBLE_WEIGHT_EXPONENT = 2;
 
 function buildLayerGroup(layerGroup) {
-  const htmlGroup = document.createElement('fieldset');
-  htmlGroup.id = layerGroup.version;
-  htmlGroup.className = 'group';
-
-  const htmlHeader = document.createElement('legend');
-  htmlHeader.textContent = (layerGroup.metadata && layerGroup.metadata.AOI)
-    ? layerGroup.metadata.AOI
-    : layerGroup.version;
-  htmlGroup.appendChild(htmlHeader);
-
-  const htmlSubmenu = document.createElement('div');
-  htmlSubmenu.className = 'submenu';
-  htmlGroup.appendChild(htmlSubmenu);
-
-  const htmlMetadataLink = document.createElement('a');
-  htmlMetadataLink.className = 'metadata-link';
-  htmlMetadataLink.href = layerGroup.metadata_url;
-  htmlMetadataLink.target = '_blank';
-  htmlMetadataLink.textContent = 'Metadata';
-  htmlSubmenu.appendChild(htmlMetadataLink);
-
-  if (pendingLayers) {
-    const htmlApproveButton = document.createElement('button');
-    htmlApproveButton.className = 'approve-button';
-    htmlApproveButton.textContent = 'Approve';
-    htmlSubmenu.appendChild(htmlApproveButton);
-
-    htmlApproveButton.onclick = function (e) {
-      htmlApproveButton.textContent = 'Approving...';
-      htmlApproveButton.onclick = function (e2) { e2 && e2.preventDefault(); return false };  //Cancel out the approve button
-
-      API.approve(eventName, layerGroup.version)
-        .then(function (res) {
-          htmlApproveButton.textContent = 'DONE!';
-        })
-        .catch(function (err) {
-          console.error(err);
-          htmlApproveButton.textContent = 'ERROR';
-        });
-      
-      e && e.preventDefault();
-      return false;
-    };
-  }
-
-  Object.values(layerGroup.layers)
-    .map(function (layer) { return buildLayerInput(layer, layerGroup) })
-    .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
   
-  // Add toggle option
-  const htmlToggle = document.createElement('button');
-  htmlToggle.textContent = 'Toggle group';
-  htmlToggle.onclick = function (e) {
-    const version = layerGroup.version;
-    const checkboxes = Array.from(document.querySelectorAll(`.layer-control[data-group='${version}'] input[type='checkbox']`));
-
-    //If any checkboxes are checked, uncheck them all. Otherwise, check them all.
-    const anySelected = !!checkboxes.find(function (checkbox) { return checkbox.checked });
-    checkboxes.forEach(function (checkbox) { checkbox.checked = !anySelected });
-    
-    toggleMultipleLayers(version);
-    
-    e && e.preventDefault();
-    return false;
-  };
-  htmlGroup.appendChild(htmlToggle);
-
-  return htmlGroup;
 }
 
 function buildLayerInput(layer, layerGroup) {
@@ -363,13 +296,79 @@ class MapApp {
     });
     
     Object.values(HEATMAP_GROUPS)
-      //.map(this.buildMapControls_layerGroups)
-      .map(buildLayerGroup)
+      .map(this.buildMapControls_layerGroups)
       .forEach(function (htmlGroup) { MAP_SELECT.appendChild(htmlGroup) });
   }
   
   buildMapControls_layerGroups (layerGroup) {
-    
+    const htmlGroup = document.createElement('fieldset');
+    htmlGroup.id = layerGroup.version;
+    htmlGroup.className = 'group';
+
+    const htmlHeader = document.createElement('legend');
+    htmlHeader.textContent = (layerGroup.metadata && layerGroup.metadata.AOI)
+      ? layerGroup.metadata.AOI
+      : layerGroup.version;
+    htmlGroup.appendChild(htmlHeader);
+
+    const htmlSubmenu = document.createElement('div');
+    htmlSubmenu.className = 'submenu';
+    htmlGroup.appendChild(htmlSubmenu);
+
+    const htmlMetadataLink = document.createElement('a');
+    htmlMetadataLink.className = 'metadata-link';
+    htmlMetadataLink.href = layerGroup.metadata_url;
+    htmlMetadataLink.target = '_blank';
+    htmlMetadataLink.textContent = 'Metadata';
+    htmlSubmenu.appendChild(htmlMetadataLink);
+
+    if (pendingLayers) {
+      const htmlApproveButton = document.createElement('button');
+      htmlApproveButton.className = 'approve-button';
+      htmlApproveButton.textContent = 'Approve';
+      htmlSubmenu.appendChild(htmlApproveButton);
+
+      htmlApproveButton.onclick = function (e) {
+        htmlApproveButton.textContent = 'Approving...';
+        htmlApproveButton.onclick = function (e2) { e2 && e2.preventDefault(); return false };  //Cancel out the approve button
+
+        API.approve(eventName, layerGroup.version)
+          .then(function (res) {
+            htmlApproveButton.textContent = 'DONE!';
+          })
+          .catch(function (err) {
+            console.error(err);
+            htmlApproveButton.textContent = 'ERROR';
+          });
+
+        e && e.preventDefault();
+        return false;
+      };
+    }
+
+    Object.values(layerGroup.layers)
+      .map(function (layer) { return buildLayerInput(layer, layerGroup) })
+      .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
+
+    // Add toggle option
+    const htmlToggle = document.createElement('button');
+    htmlToggle.textContent = 'Toggle group';
+    htmlToggle.onclick = function (e) {
+      const version = layerGroup.version;
+      const checkboxes = Array.from(document.querySelectorAll(`.layer-control[data-group='${version}'] input[type='checkbox']`));
+
+      //If any checkboxes are checked, uncheck them all. Otherwise, check them all.
+      const anySelected = !!checkboxes.find(function (checkbox) { return checkbox.checked });
+      checkboxes.forEach(function (checkbox) { checkbox.checked = !anySelected });
+
+      toggleMultipleLayers(version);
+
+      e && e.preventDefault();
+      return false;
+    };
+    htmlGroup.appendChild(htmlToggle);
+
+    return htmlGroup;
   }
   
   chooseLayerColour (index) {

--- a/js/maps.js
+++ b/js/maps.js
@@ -23,8 +23,7 @@ const HEATMAP_DATA = {};
 // Pre-set colour gradients - provides the best contrast on a predominantly blue-green map.
 // The first step in each gradient must be fully transparent, to indicate the 0-value.
 let HEATMAP_GRADIENT = [  
-  'rgba(255, 255, 0, 0.0)',
-  'rgba(255, 255, 0, 0.5)',
+  'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)',
 ];
 
 // The dots are more visible on the map with a higher weight.
@@ -77,7 +76,7 @@ function buildLayerGroup(layerGroup) {
     };
   }
 
-  layerGroup.layers
+  Object.values(layerGroup.layers)
     .map(function (layer) { return buildLayerInput(layer, layerGroup) })
     .forEach(function (htmlLayer) { htmlGroup.appendChild(htmlLayer) });
   
@@ -318,8 +317,8 @@ class MapApp {
 
   fetchMapData () {
     API[getLayerFunc](eventName, layer)
-      .then(this.saveMapData)
-      .then(this.buildMapControls)
+      .then(this.saveMapData.bind(this))
+      .then(this.buildMapControls.bind(this))
       .then(function () {
         if (layer) {
           renderMap(zoomToFit);
@@ -342,8 +341,10 @@ class MapApp {
           url: layer.url,
           description: metadata.description,
           legend: metadata.legend,
+          colour: this.chooseLayerColour(index),
+          gradient: this.chooseLayerGradient(index),
         };
-      })
+      }.bind(this))
 
       HEATMAP_GROUPS[group.version] = {
         version: group.version,
@@ -351,7 +352,7 @@ class MapApp {
         metadataUrl: group.metadata_url,
         layers,
       };
-    });
+    }.bind(this));
     
     return layerGroups;
   }
@@ -361,9 +362,30 @@ class MapApp {
       MAP_SELECT.removeChild(node);
     });
     
-    layerGroups
+    Object.values(HEATMAP_GROUPS)
+      //.map(this.buildMapControls_layerGroups)
       .map(buildLayerGroup)
       .forEach(function (htmlGroup) { MAP_SELECT.appendChild(htmlGroup) });
+  }
+  
+  buildMapControls_layerGroups (layerGroup) {
+    
+  }
+  
+  chooseLayerColour (index) {
+    const colours = [
+      'rgba(255, 255, 0, 1.0)',
+      'rgba(255, 0, 255, 1.0)',
+    ];
+    return colours[Math.max(index, colours.length - 1)];
+  }
+  
+  chooseLayerGradient (index) {
+    const colours = [
+      [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)', ],
+      [ 'rgba(255, 0, 255, 0.0)', 'rgba(255, 0, 255, 0.5)', ],
+    ];
+    return colours[Math.max(index, colours.length - 1)];
   }
 }
 

--- a/js/maps.js
+++ b/js/maps.js
@@ -170,8 +170,6 @@ function filteredMapData(results) {
 
 function parseMapData(results, url) {
   // For each heatmap, assign a preset colour to it.
-  const numberOfHeatmaps = Object.keys(HEATMAPS).length;
-
   const heatmap = new google.maps.visualization.HeatmapLayer({
     gradient: HEATMAP_GRADIENT,
     maxIntensity: 30,
@@ -228,16 +226,6 @@ function toggleMultipleLayers(layerGroupVersion) {
       HEATMAPS[url] && HEATMAPS[url].setMap(null);
     }
   });
-  
-  /*if (event.target.checked) {
-    if (HEATMAPS[url]) {
-      HEATMAPS[url].setMap(GOOGLE_MAP);
-    } else {
-      readMapFile(url);
-    }
-  } else {
-    HEATMAPS[url] && HEATMAPS[url].setMap(null);
-  }*/
 }
 
 function renderMap(resolveFunc) {
@@ -273,7 +261,7 @@ function updateMapControlsUI () {
   }
 }
 
-function FitEventBounds() {
+function fitEventBounds() {
   API.event(eventName)
   .then(function (event) {
     const boundingBoxCoords = event.bounding_box_coords;
@@ -337,7 +325,7 @@ class MapApp {
           renderMap(zoomToFit);
         } else {
           renderMap();
-          FitEventBounds();
+          fitEventBounds();
         }
       });
   }

--- a/js/maps.js
+++ b/js/maps.js
@@ -142,7 +142,7 @@ if (pendingLayers) {
 class MapApp {
   constructor () {
     // MAP_SELECT_FORM.addEventListener('change', this.updateSelectedMap);
-    MAP_THRESHOLD.addEventListener('change', this.renderMap);
+    MAP_THRESHOLD.addEventListener('change', this.renderMap.bind(this));
     ZOOM_TO_FIT.addEventListener('click', zoomToFit);
     
     this.fetchMapData();

--- a/js/maps.js
+++ b/js/maps.js
@@ -221,6 +221,7 @@ class MapApp {
         const metadata = (group.metadata && group.metadata.layers && group.metadata.layers[index]) || {};
         layers[layer.url] = {
           name: layer.name,
+          group: group.version,
           url: layer.url,
           description: metadata.description,
           legend: metadata.legend,
@@ -322,18 +323,12 @@ class MapApp {
   }
   
   buildMapControls_layerHtml (layer, layerGroup) {
-    const layerMetadata = (layerGroup && layerGroup.metadata && layerGroup.metadata.layers)
-      ? layerGroup.metadata.layers.find(function (layermeta) { return layer.url.endsWith(`/${layermeta.file_name}`) })
-      : undefined;
-
     const div = document.createElement('div');
     const label = document.createElement('label');
     const checkbox = document.createElement('input');
     const span = document.createElement('span');
 
-    span.textContent = (layerMetadata && layerMetadata.description)
-      ? layerMetadata.description
-      : layer.name;
+    span.textContent = layer.description;
 
     checkbox.type = 'checkbox';
     checkbox.value = layer.url;
@@ -345,9 +340,7 @@ class MapApp {
     div.appendChild(label);
 
     // Add legends, if any.
-    const legends = (HEATMAP_GROUPS[layerGroup.version] && HEATMAP_GROUPS[layerGroup.version].layers[layer.url])
-      ? HEATMAP_GROUPS[layerGroup.version].layers[layer.url].legend
-      : [];
+    const legends = (layer && layer.legend) || [];
     if (legends && legends.length > 0) {
       const ol = document.createElement('ol');
       ol.className = 'layer-control-legends';
@@ -361,7 +354,7 @@ class MapApp {
     }
 
     div.className = 'layer-control';
-    div.dataset.group = layerGroup.version;
+    div.dataset.group = layer.group;
     div.dataset.layer = layer.name;
     div.dataset.url = layer.url;
 
@@ -373,6 +366,8 @@ class MapApp {
       'rgba(255, 255, 0, 1.0)',
       'rgba(255, 0, 255, 1.0)',
       'rgba(0, 255, 255, 1.0)',
+      'rgba(255, 0, 0, 1.0)',
+      'rgba(0, 255, 0, 1.0)',
     ];
     return colours[Math.min(index, colours.length - 1)];
   }
@@ -382,6 +377,8 @@ class MapApp {
       [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)', ],
       [ 'rgba(255, 0, 255, 0.0)', 'rgba(255, 0, 255, 0.5)', ],
       [ 'rgba(0, 255, 255, 0.0)', 'rgba(0, 255, 255, 0.5)', ],
+      [ 'rgba(255, 0, 0, 0.0)', 'rgba(255, 0, 0, 0.5)', ],
+      [ 'rgba(0, 255, 0, 0.0)', 'rgba(0, 255, 0, 0.5)', ],
     ];
     return colours[Math.min(index, colours.length - 1)];
   }


### PR DESCRIPTION
## PR Overview

This PR is part of a mega-update for June 2019; this includes a major UI change for users and a lot of back end refactoring to make the code easier to update for the future.

For the users:
- Users can only view one map layer at a time, since (based on feedback) this is the intended use case.
  - Goodbye checkboxes, hello radio buttons. Although in the near future I may introduce a "keep layer visible" checkbox.
- Each map layer now has its own map colour.

<img width="1003" alt="Screen Shot 2019-06-28 at 18 20 16" src="https://user-images.githubusercontent.com/13952701/60360705-41595200-99d4-11e9-8547-9be0e9470f82.png">

For the devs:
- Most of the standalone functions have been gathered into a `MapApp` class.
  - This map object can be accessed via `window.mapApp` for debugging.
- Heatmap layers and groups are now organised in the global `HEATMAP_DATA` data store.
  - This data store keeps track of various UI states and values, e.g. the individual colours of each layer.

WARNINGS:
- Issues running in Safari detected. Apparently, the 'API' variable can't be detected. Not sure if this is related to #40 (UPDATE: yup! Fixed by the merge resolution)
- The refactor is still a bit of a WIP. 

### Status

Planning to merge, once merge conflicts are resolved.