### PR TITLE
Jul 2019 update - multi-colours for multi-intensity Layers

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -2,7 +2,6 @@ import { queryParams } from './queryParams.js';
 import { API } from './api.js';
 
 const HTML_MAP_CONTAINER = document.getElementById('map');
-const HTML_MAP_THRESHOLD = document.getElementById('map-threshold');
 const HTML_MAP_SELECT = document.getElementById('map-select');
 const HTML_ZOOM_TO_FIT = document.getElementById('zoom-to-fit');
 const MAP_OPTIONS = {
@@ -104,7 +103,6 @@ function parseMapData (results, layer) {
         maxIntensity: MAX_INTENSITY,
         opacity: 1
       });
-      
       layer.heatmap.push(newHeatmap);
     });
 
@@ -253,7 +251,6 @@ MapApp is the primary engine for showing and controlling maps on the web page.
  */
 class MapApp {
   constructor () {
-    HTML_MAP_THRESHOLD.addEventListener('change', this.renderMap.bind(this));
     HTML_ZOOM_TO_FIT.addEventListener('click', zoomToFit);
     
     this.fetchMapData();
@@ -391,7 +388,9 @@ class MapApp {
       this.activateLayer(layer);
     });
 
-    label.style.borderRight = `0.5em solid ${layer.colour}`;
+    const colour = (layer.hasSingleIntensity()) ? layer.colour : 'transparent';
+    
+    label.style.borderRight = `1em solid ${colour}`;
     label.appendChild(input)
     label.appendChild(span);
     div.appendChild(label);
@@ -405,6 +404,7 @@ class MapApp {
         const li = document.createElement('li');
         li.textContent = legend;
         li.dataset.legendValue = index + 1;
+        li.style.borderRight = `0.5em solid ${layer.colour[index]}`;
         ol.appendChild(li);
       });
       div.appendChild(ol);
@@ -419,7 +419,15 @@ class MapApp {
   }
   
   chooseLayerColour (index, hasMultipleIntensities) {
-    if (hasMultipleIntensities) return 'rgba(255, 0, 0, 1.0)';
+    if (hasMultipleIntensities) {
+      return [
+        'rgba(255, 255, 0, 1.0)',
+        'rgba(255, 192, 0, 1.0)',
+        'rgba(255, 128, 0, 1.0)',
+        'rgba(255, 64, 0, 1.0)',
+        'rgba(255, 0, 0, 1.0)',
+      ];
+    }
     
     const colours = [
       'rgba(255, 255, 0, 1.0)',
@@ -465,21 +473,6 @@ class MapApp {
         }
       }
     });
-    this.updateMapControlsUI();
-  }
-  
-  updateMapControlsUI () {
-    const threshold = parseInt(HTML_MAP_THRESHOLD.value);
-    const thresholdMin = Number.parseInt(HTML_MAP_THRESHOLD.min);
-    const thresholdMax = Number.parseInt(HTML_MAP_THRESHOLD.max);
-
-    for (let val = thresholdMin; val <= thresholdMax; val++) {
-      const selectedElements = document.querySelectorAll(`.layer-control-legends li[data-legend-value='${val}']`);
-      Array.from(selectedElements).forEach((element) => {
-        if (val >= threshold) element.className = 'selected';
-        else element.className = 'unselected';
-      });
-    }
   }
   
   activateLayer (layer) {

--- a/js/maps.js
+++ b/js/maps.js
@@ -396,7 +396,7 @@ class MapApp {
 
     const colour = (layer.hasSingleIntensity()) ? layer.colour : 'transparent';
     
-    label.style.borderRight = `1em solid ${colour}`;
+    label.style.borderRight = `0.5em solid ${colour}`;
     label.appendChild(input)
     label.appendChild(span);
     div.appendChild(label);
@@ -427,20 +427,20 @@ class MapApp {
   chooseLayerColour (index, hasMultipleIntensities) {
     if (hasMultipleIntensities) {
       return [
+        'rgba(255, 255, 192, 1.0)',
         'rgba(255, 255, 0, 1.0)',
-        'rgba(255, 192, 0, 1.0)',
         'rgba(255, 128, 0, 1.0)',
-        'rgba(255, 64, 0, 1.0)',
         'rgba(255, 0, 0, 1.0)',
+        'rgba(255, 0, 128, 1.0)',
       ];
     }
     
     const colours = [
-      'rgba(255, 255, 0, 1.0)',
-      'rgba(255, 0, 255, 1.0)',
+      'rgba(192, 128, 0, 1.0)',
+      'rgba(192, 0, 255, 1.0)',
       'rgba(0, 255, 255, 1.0)',
-      'rgba(0, 255, 0, 1.0)',
-      'rgba(255, 0, 0, 1.0)',
+      'rgba(0, 255, 128, 1.0)',
+      'rgba(255, 0, 255, 1.0)',
     ];
     return colours[Math.min(index, colours.length - 1)];
   }
@@ -448,20 +448,20 @@ class MapApp {
   chooseLayerGradient (index, hasMultipleIntensities) {
     if (hasMultipleIntensities) {
       return [
-        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)', ],
-        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 192, 0, 0.5)', ],
-        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 128, 0, 0.5)', ],
-        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 64, 0, 0.5)', ],
-        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 0, 0, 0.5)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 192, 0.7)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.7)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 128, 0, 0.7)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 0, 0, 0.7)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 0, 128, 0.7)', ],
       ];
     }
     
     const colours = [
-      [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)', ],
-      [ 'rgba(255, 0, 255, 0.0)', 'rgba(255, 0, 255, 0.5)', ],
-      [ 'rgba(0, 255, 255, 0.0)', 'rgba(0, 255, 255, 0.5)', ],
-      [ 'rgba(0, 255, 0, 0.0)', 'rgba(0, 255, 0, 0.5)', ],
-      [ 'rgba(255, 0, 0, 0.0)', 'rgba(255, 0, 0, 0.5)', ],
+      [ 'rgba(255, 255, 255, 0.0)', 'rgba(192, 128, 0, 0.7)', ],
+      [ 'rgba(255, 255, 255, 0.0)', 'rgba(192, 0, 255, 0.7)', ],
+      [ 'rgba(255, 255, 255, 0.0)', 'rgba(0, 255, 255, 0.7)', ],
+      [ 'rgba(255, 255, 255, 0.0)', 'rgba(0, 255, 128, 0.7)', ],
+      [ 'rgba(255, 255, 255, 0.0)', 'rgba(255, 0, 255, 0.7)', ],
     ];
     return colours[Math.min(index, colours.length - 1)];
   }

--- a/js/maps.js
+++ b/js/maps.js
@@ -129,6 +129,34 @@ if (pendingLayers) {
   getLayerFunc = 'layer';
 }
 
+class LayerGroup {
+  constructor (initialProps) {
+    this.version = '',
+    this.name = '',
+    this.metadataUrl = '',
+    this.layers = [];
+    
+    Object.assign(this, initialProps);
+  }
+}
+
+class Layer {
+  constructor (initialProps) {
+    this.name = '',
+    this.group = '',
+    this.url = '',
+    this.description = '';
+    this.legend = undefined;
+    this.colour = [];
+    this.gradient = [];
+    this.heatmap = undefined;
+    this.csvData = undefined;
+    this.show = false;
+    
+    Object.assign(this, initialProps);
+  }
+}
+
 class MapApp {
   constructor () {
     // HTML_MAP_SELECT.addEventListener('change', this.updateSelectedMap);
@@ -159,7 +187,7 @@ class MapApp {
       let layers = {};
       group.layers.forEach((layer, index) => {
         const metadata = (group.metadata && group.metadata.layers && group.metadata.layers[index]) || {};
-        layers[layer.url] = {
+        layers[layer.url] = new Layer({
           name: layer.name,
           group: group.version,
           url: layer.url,
@@ -170,15 +198,15 @@ class MapApp {
           heatmap: undefined,
           csvData: undefined,
           show: false,
-        };
+        });
       })
 
-      HEATMAP_DATA[group.version] = {
+      HEATMAP_DATA[group.version] = new LayerGroup({
         version: group.version,
         name: group.metadata.AOI,
         metadataUrl: group.metadata_url,
         layers,
-      };
+      });
     });
     
     return layerGroups;

--- a/js/maps.js
+++ b/js/maps.js
@@ -24,8 +24,7 @@ const VISIBLE_WEIGHT_MULTIPLIER = 1;
 const VISIBLE_WEIGHT_EXPONENT = 1;
 
 function minimumWeight ([lat, lng, weight]) {
-  const threshold = parseInt(HTML_MAP_THRESHOLD.value);
-  return weight >= threshold;
+  return weight > 1;  // Data context: for PRN maps, every point on the map has a minimum weight of 1.
 }
 
 function parseLine ([lat, lng, weight]) {
@@ -88,15 +87,16 @@ function parseMapData (results, layer) {
     
   } else {
     
-    const MAX_INTENSITY = (layer.legend && layer.legend.length) || 1;
+    const MAX_INTENSITY = 2;  // Artificially lower the intensity instead of using layer.legend.length
+    // Context: this creates better visuals since the differentiator between
+    // intensities should be the colours, not necessarily the opacity & size
+    //  as is the default with Google heatmaps.
     
     // If a heatmap already exists, remove it.
     layer.hideHeatmap();
 
     // Add the new heatmap _for each intensity_ (each legend item = 1 intensity)
     layer.heatmap = [];
-    
-    // TODO
     
     layer.legend && layer.legend.forEach((legend, index) => {
       const newHeatmap = new google.maps.visualization.HeatmapLayer({
@@ -216,13 +216,11 @@ class Layer {
       this.heatmap.setMap(targetMap);
     } else {
       Array.isArray(this.heatmap) && this.heatmap.forEach((heatmap, index) => {
-        // TODO
-        
-        const intensity = index + 2;
+        const intensity = index + 2;  // TODO: check this arbitrary maths
         
         const heatmapData = this.csvData && this.csvData.data
           .filter(([lat, lng, weight]) => {
-            return weight == intensity;
+            return weight == intensity;  // TODO: check that this doesn't miss out on anything
           })
           .map(parseLine);
         
@@ -431,11 +429,11 @@ class MapApp {
   chooseLayerGradient (index, hasMultipleIntensities) {
     if (hasMultipleIntensities) {
       return [
-        [ 'rgba(255, 128, 0, 0.0)', 'rgba(255, 128, 0, 0.5)', ],
-        [ 'rgba(255, 96, 0, 0.0)', 'rgba(255, 96, 0, 0.5)', ],
-        [ 'rgba(255, 64, 0, 0.0)', 'rgba(255, 64, 0, 0.5)', ],
-        [ 'rgba(255, 32, 0, 0.0)', 'rgba(255, 32, 0, 0.5)', ],
-        [ 'rgba(255, 0, 0, 0.0)', 'rgba(255, 0, 0, 0.5)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 255, 0, 0.5)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 192, 0, 0.5)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 128, 0, 0.5)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 64, 0, 0.5)', ],
+        [ 'rgba(255, 255, 0, 0.0)', 'rgba(255, 0, 0, 0.5)', ],
       ];
     }
     

--- a/js/maps.js
+++ b/js/maps.js
@@ -138,7 +138,12 @@ function zoomToFit () {
         bounds.extend(point.location);
       });
     } else {
-      // TODO
+      layer.show && layer.heatmap && layer.heatmap.forEach((heatmap) => {
+        const data = heatmap.getData();
+        data.forEach((point) => {
+          bounds.extend(point.location);
+        });
+      });      
     }
   });
   GOOGLE_MAP.fitBounds(bounds);

--- a/js/maps.js
+++ b/js/maps.js
@@ -71,7 +71,7 @@ function cacheMapData (results, file, layer) {
 
 function parseMapData (results, layer) {
   
-  if (!layer.hasMultipleHeatmaps()) {
+  if (layer.hasSingleIntensity()) {
     
     // If a heatmap already exists, remove it.
     if (layer.heatmap) layer.heatmap.setMap(null);
@@ -113,7 +113,7 @@ function fitEventBounds () {
 function zoomToFit () {
   const bounds  = new google.maps.LatLngBounds();
   selectAllLayers().forEach((layer) => {
-    if (!layer.hasMultipleHeatmaps()) {
+    if (layer.hasSingleIntensity()) {
       const data = layer.show && layer.heatmap && layer.heatmap.getData() || [];
       data.forEach((point) => {
         bounds.extend(point.location);
@@ -180,14 +180,18 @@ class Layer {
     Object.assign(this, initialProps);
   }
   
-  hasMultipleHeatmaps () {
+  hasSingleIntensity () {
+    return !this.hasMultipleIntensities();
+  }
+  
+  hasMultipleIntensities () {
     return (this.legend && this.legend.length > 0) || (this.heatmap && Array.isArray(this.heatmap));
   }
   
   showHeatmap (targetMap) {
     if (!this.heatmap) return;
     
-    if (!this.hasMultipleHeatmaps()) {
+    if (this.hasSingleIntensity()) {
       const heatmapData = filteredMapData(this.csvData);
       this.heatmap.setData(heatmapData);
       this.heatmap.setMap(targetMap);
@@ -201,7 +205,7 @@ class Layer {
   hideHeatmap () {
     if (!this.heatmap) return;
     
-    if (!this.hasMultipleHeatmaps()) {
+    if (this.hasSingleIntensity()) {
       this.heatmap.setMap(null);
     } else {
       Array.isArray(this.heatmap) && this.heatmap.forEach((heatmap) => {

--- a/maps/index.html
+++ b/maps/index.html
@@ -16,18 +16,6 @@
       </fieldset>
     </form>
     <div id="map-filters">
-      <label>
-        Threshold:
-        1
-        <input
-          id="map-threshold"
-          type="range"
-          min="1"
-          max="5"
-          value="2"
-        >
-        5
-      </label>
       <button id="zoom-to-fit">Zoom to fit</button>
     </div>
   </div>


### PR DESCRIPTION
## PR Overview

This PR intends to add multiple unique colours for multi-intensity Layers. Specifically, the common "Building Damage" has four known intensities _("<20% damaged", "20-40% damaged", etc)_ and, according to our primary user, those intensities are difficult to distinguish if they're all the same colour.

![Screen Shot 2019-07-15 at 18 58 55](https://user-images.githubusercontent.com/13952701/61237565-a336ed00-a732-11e9-8e5a-b6f6026eb7ed.png)
_PRN Map showing higher-intensity POIs as more orange-looking blobs._

### Dev Notes

For these mult-intensity Layers, our primary user wishes for each POI's intensity to be coloured differently - essentially, we want a choropleth map with each 'section' being a single dot or point of interest.

Current implementation is to create a separate heatmap for each intensity, meaning multi-intensity Layers will have multiple heatmap objects.

NOTE: we _could_ have gone with the simpler method of simply customising the Layer's gradient, but the problem is that at different zoom levels, the intensities get smooshed together, so a concentration of many low-intensity POIs might look like a high-intensity POI. We basically _don't_ want the colours to operate like a normal heatmap colour gradient. 😐 

### Status

WIP