### PR TITLE
Auto re-frame map when changing Layers

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -474,6 +474,7 @@ class MapApp {
       } else {
         if (layer && layer.heatmap) {
           layer.showHeatmap(GOOGLE_MAP);
+          if (resolveFunction) resolveFunction();
         } else {
           readMapFile(layer, resolveFunction);
         }
@@ -484,14 +485,16 @@ class MapApp {
   activateLayer (layer) {
     // If the user activated a layer that's in a different group, it's a good
     // idea to reframe the view to show the new group.
-    const autoZoomToFitIsAGoodIdea = this.shouldWeZoomToFit(layer);
-    console.log('+++ autoZoomToFitIsAGoodIdea: ', autoZoomToFitIsAGoodIdea)
+    const autoZoomIsAGoodIdea = this.shouldWeZoomToFit(layer);
     
     this.deactivateAllLayers();
     layer.show = true;
     
-    if (autoZoomToFitIsAGoodIdea) this.renderMap(zoomToFit);
-    else this.renderMap();
+    if (autoZoomIsAGoodIdea) {
+      this.renderMap(zoomToFit);
+    } else {
+      this.renderMap();
+    }
   }
   
   deactivateAllLayers () {
@@ -503,9 +506,6 @@ class MapApp {
       const group = HEATMAP_DATA[groupId];
       return Object.keys(group.layers).find(layerId => group.layers[layerId].show);
     });
-    
-    console.log('+++ currentActiveGroup: ', currentActiveGroup)
-    console.log('+++ newlyActivatedLayer.group: ', newlyActivatedLayer.group)
     
     return (currentActiveGroup !== newlyActivatedLayer.group);
   }

--- a/js/maps.js
+++ b/js/maps.js
@@ -482,13 +482,32 @@ class MapApp {
   }
   
   activateLayer (layer) {
+    // If the user activated a layer that's in a different group, it's a good
+    // idea to reframe the view to show the new group.
+    const autoZoomToFitIsAGoodIdea = this.shouldWeZoomToFit(layer);
+    console.log('+++ autoZoomToFitIsAGoodIdea: ', autoZoomToFitIsAGoodIdea)
+    
     this.deactivateAllLayers();
     layer.show = true;
-    this.renderMap();
+    
+    if (autoZoomToFitIsAGoodIdea) this.renderMap(zoomToFit);
+    else this.renderMap();
   }
   
   deactivateAllLayers () {
     selectAllLayers().forEach((layer) => { layer.show = false; });
+  }
+  
+  shouldWeZoomToFit (newlyActivatedLayer = {}) {
+    const currentActiveGroup = Object.keys(HEATMAP_DATA).find(groupId => {
+      const group = HEATMAP_DATA[groupId];
+      return Object.keys(group.layers).find(layerId => group.layers[layerId].show);
+    });
+    
+    console.log('+++ currentActiveGroup: ', currentActiveGroup)
+    console.log('+++ newlyActivatedLayer.group: ', newlyActivatedLayer.group)
+    
+    return (currentActiveGroup !== newlyActivatedLayer.group);
   }
 }
 


### PR DESCRIPTION
## PR Overview

Closes #44 

UI improvement: this PR re-frames the map (i.e. triggers "Zoom to Fit") when the user selects a Layer that belongs to a different Group. This helps make sure that a user always has their eyes on data of importance.

### Status

WIP - currently experiencing an issue where the Zoom function doesn't trigger when re-visiting a Group (aka AOI, in the map's terminology) that was previously zoomed to. 