### PR TITLE
Reduce MIN_INTENSITY to reflect changes to supplied data

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -24,9 +24,14 @@ const VISIBLE_WEIGHT_EXPONENT = 1;
 
 // IMPORTANT: for PRN maps, every point on the map has a minimum weight of 1.
 // This includes POIs where there's nothing of interest happening. Essentually,
-// this means that when we display a heatmap, we essentially anything that's of
-// the minimum intensity
-const MIN_INTENSITY = 1;
+// this means that when we display a heatmap, we essentially clutter the map
+// with points EVERYWHERE.
+// const MIN_INTENSITY = 1;
+
+// HOTFIX 20190911: ignore what that previous block of code said. They data
+// suppliers have now changed the newer data sets so that POIs with nothing
+// happening aren't listed, so a weight of 1 actually means something now.
+const MIN_INTENSITY = 0;
 
 // IMPORTANT: for PRN maps, there's a known maximum weight. However, for visual
 // presentation purposes, we often use a lower artificial max intensity to make


### PR DESCRIPTION
## PR Overview

With previous test data, i.e. `caribbean_2018_demo`, the map data had a base intensity/weight of 1 for EVERY P.O.I. This meant that even on points of the map where nothing was happening, it had an intensity of 1. We introduced the `MIN_INTENSITY` value in the map to ensure the map renderer ignores all these minimum values, to prevent cluttering the map with pointless points.

With more recent data, however - i.e. `bahamas_hurricane_dorian_2019` - the low-level 'nothing happening here' POIs have been removed. POIs with something happening now occupy a value of 1 or more, whereas POIs where nothing's happening aren't listed at all.

As a result, we've changed MIN_INTENSITY to 0. The new data now shows properly, though the old data is now a bit of a mess.

![Screen Shot 2019-09-11 at 12 09 40](https://user-images.githubusercontent.com/13952701/64692502-30759400-d48d-11e9-9504-a2d2d669be86.png)
_Example of caribbean_2018_demo data map being cluttered_

The new data takes priority, however. A more flexible solution is currently being investigated.

### Status

Priority merge