### PR TITLE
Add Extra Info to Layer Groups

### DIFF
--- a/css/map-page.css
+++ b/css/map-page.css
@@ -27,6 +27,13 @@
 #map-select label {
   display: block;
 }
+#map-select .extra-info {
+  overflow: auto;
+  white-space: pre;
+  font-size: 0.75em;
+  background: #eee;
+  padding: 0.25em;
+}
 #map-select .submenu {
   background: #ccc;
   padding: 0.25em;

--- a/js/maps.js
+++ b/js/maps.js
@@ -181,6 +181,7 @@ class LayerGroup {
   constructor (initialProps) {
     this.version = '',
     this.name = '',
+    this.uploadedAt = '';
     this.metadataUrl = '',
     this.layers = [];
     
@@ -307,6 +308,7 @@ class MapApp {
       HEATMAP_DATA[group.version] = new LayerGroup({
         version: group.version,
         name: group.metadata.AOI,
+        uploadedAt: group.metadata.uploaded_at,
         metadataUrl: group.metadata_url,
         layers,
       });
@@ -337,10 +339,13 @@ class MapApp {
     htmlGroup.className = 'group';
 
     const htmlHeader = document.createElement('legend');
-    htmlHeader.textContent = (layerGroup.metadata && layerGroup.metadata.AOI)
-      ? layerGroup.metadata.AOI
-      : layerGroup.version;
+    htmlHeader.textContent = layerGroup.name || layerGroup.version;
     htmlGroup.appendChild(htmlHeader);
+    
+    const htmlExtraInfo = document.createElement('div');
+    htmlExtraInfo.className = 'extra-info';
+    htmlExtraInfo.textContent = `Name: ${layerGroup.name}\r\nVer: ${layerGroup.version}\r\nUploaded: ${layerGroup.uploadedAt}`; 
+    htmlGroup.appendChild(htmlExtraInfo);
 
     const htmlSubmenu = document.createElement('div');
     htmlSubmenu.className = 'submenu';


### PR DESCRIPTION
## PR Overview

closes #43 

This PR adds an extra info panel to each Layer Group, describing:
- the layer group's name
- its version
- when the layer group was uploaded.

Also, I fixed a bug where the Layer Group's `<legend>` was showing `v2` instead of `Group Name X`

![Screen Shot 2019-09-11 at 12 32 36](https://user-images.githubusercontent.com/13952701/64694564-d4613e80-d491-11e9-9ca9-6878ae0ba8b0.png)

### Status

Priority merge

Note: I accidentally pushed this commit directly to `master` earlier, whoops; I rolled that back and made this proper PR. There shouldn't be any weirdness in the Git history, but please let me know if you spot anything.